### PR TITLE
Use url configuration for link elements

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -55,10 +55,10 @@ module.exports = ({
     Object.assign(res.locals, {
       scripts: [`/public/js/${pagePath}/${filename}/bundle.js`],
       rootReducer: combineReducers(rootReducer),
-      static: {
+      static: Object.assign(res.locals.static, {
         url,
         content: merge({}, res.locals.static.content, pages[req.path].content, content)
-      }
+      })
     });
     res.template = pages[req.path].template;
     return next();

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -2,12 +2,18 @@ module.exports = {
   siteTitle: 'Research and testing with animals',
   beta: 'This is a new service - your [feedback](mailto:animalscience@digital.homeoffice.gov.uk) will help us to improve it.',
   pages: {
-    establishments: 'Establishments',
-    details: 'Establishment details',
-    people: 'People',
-    places: 'Licensed premises',
-    projects: 'Projects',
+    establishment: {
+      list: 'Establishments',
+      details: 'Establishment details'
+    },
+    profile: {
+      list: 'Named people and licence holders'
+    },
+    project: {
+      list: 'Projects'
+    },
     place: {
+      list: 'Licensed premises',
       edit: 'Change licensed premises',
       confirm: 'Confirm changes'
     }

--- a/pages/common/views/components/link.jsx
+++ b/pages/common/views/components/link.jsx
@@ -1,11 +1,29 @@
 import React from 'react';
+import { get } from 'lodash';
+
+const replace = params => fragment => {
+  return fragment[0] === ':' ? params[fragment.substr(1)] : fragment;
+};
 
 const Link = ({
   url,
+  urls,
+  page,
   path,
-  label
-}) => (
-  <a href={`${url}/${path}`}>{label}</a>
-);
+  label,
+  ...props
+}) => {
+  if (page) {
+    const href = get(urls, page);
+    if (!href) {
+      throw new Error(`Unknown link target: ${page}`);
+    }
+    const replacer = replace(props);
+    url = href.split('/').map(replacer).join('/');
+    return <a href={url}>{label}</a>;
+  } else {
+    return <a href={`${url}/${path}`}>{label}</a>;
+  }
+};
 
 export default Link;

--- a/pages/common/views/containers/link.jsx
+++ b/pages/common/views/containers/link.jsx
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 import Link from '../components/link';
 
-const mapStateToProps = ({ static: { url } }) => ({ url });
+const mapStateToProps = ({ static: { url, urls, establishment } }, props) => {
+  establishment = props.establishment || (establishment || {}).id;
+  return { url, urls, establishment };
+};
 
 export default connect(mapStateToProps)(Link);

--- a/pages/establishment/dashboard/content/index.js
+++ b/pages/establishment/dashboard/content/index.js
@@ -1,16 +1,24 @@
 module.exports = {
   dashboard: {
-    details: {
-      subtitle: 'Contact information for this establishment, as well as any conditions and authorisations.'
+    establishment: {
+      details: {
+        subtitle: 'Contact information for this establishment, as well as any conditions and authorisations.'
+      }
     },
-    people: {
-      subtitle: 'Named people, licence holders, and the Home Office Liason Contact.'
+    profile: {
+      list: {
+        subtitle: 'Named people, licence holders, and the Home Office Liason Contact.'
+      }
     },
-    places: {
-      subtitle: 'Approved areas in this establishment where animals may be used.'
+    place: {
+      list: {
+        subtitle: 'Approved areas in this establishment where animals may be used.'
+      }
     },
-    projects: {
-      subtitle: 'Projects with primary availability at this establishment.'
+    project: {
+      list: {
+        subtitle: 'Projects with primary availability at this establishment.'
+      }
     }
   }
 };

--- a/pages/establishment/dashboard/tests/index.js
+++ b/pages/establishment/dashboard/tests/index.js
@@ -8,4 +8,11 @@ describe('Establishment Page', () => {
     assert.equal(title, 'University of Croydon');
   });
 
+  it('can access the profile of the licence holder from the sidebar', () => {
+    browser.url('/pages/establishment/dashboard');
+    browser.$('.sidebar').$('a=Leonard Martin').click();
+    const title = browser.getText('h1');
+    assert.equal(title, 'Leonard Martin');
+  });
+
 });

--- a/pages/establishment/dashboard/views/index.jsx
+++ b/pages/establishment/dashboard/views/index.jsx
@@ -5,10 +5,10 @@ import Link from '../../../common/views/containers/link';
 import Sidebar from '../../../common/views/components/sidebar';
 
 const links = [
-  'details',
-  'places',
-  'people',
-  'projects'
+  'establishment.details',
+  'place.list',
+  'profile.list',
+  'project.list'
 ];
 
 const Index = ({
@@ -29,7 +29,7 @@ const Index = ({
           {
             links.map(link =>
               <li key={link}>
-                <Link path={link} label={<Snippet>{`pages.${link}`}</Snippet>} />
+                <Link page={link} label={<Snippet>{`pages.${link}`}</Snippet>} />
                 <p><Snippet>{`dashboard.${link}.subtitle`}</Snippet></p>
               </li>
             )
@@ -42,7 +42,7 @@ const Index = ({
           <dd>{ licenceNumber }</dd>
 
           <dt><Snippet>licenceHolder</Snippet></dt>
-          <dd><Link path={`profile/${pelh.id}`} label={pelh.name} /></dd>
+          <dd><Link page="profile.view" profile={ pelh.id } label={pelh.name} /></dd>
         </dl>
       </Sidebar>
     </div>

--- a/pages/establishment/details/views/index.jsx
+++ b/pages/establishment/details/views/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import Accordion from '../../../common/views/components/accordion';
 import ExpandingPanel from '../../../common/views/components/expanding-panel';
 import Snippet from '../../../common/views/containers/snippet';
+import Link from '../../../common/views/containers/link';
 
 const Index = ({
   establishment: {
@@ -21,7 +22,7 @@ const Index = ({
     <Fragment>
       <header>
         <h2>{ name }</h2>
-        <h1><Snippet>pages.details</Snippet></h1>
+        <h1><Snippet>pages.establishment.details</Snippet></h1>
       </header>
       <div className="grid-row">
         <div className="column-two-thirds">
@@ -33,7 +34,7 @@ const Index = ({
             <dd>{ address }</dd>
 
             <dt><Snippet>licenceHolder</Snippet></dt>
-            <dd><a href={`profile/${pelh.id}`}>{ pelh.name }</a></dd>
+            <dd><Link page="profile.view" profile={ pelh.id } label={ pelh.name } /></dd>
 
             <dt><Snippet>licenced.title</Snippet></dt>
             <dd>

--- a/pages/establishment/list/views/index.jsx
+++ b/pages/establishment/list/views/index.jsx
@@ -4,11 +4,12 @@ import SearchBar from '../../../common/views/containers/search';
 import ExportLink from '../../../common/views/containers/export-link';
 import FilterSummary from '../../../common/views/containers/filter-summary';
 import Snippet from '../../../common/views/containers/snippet';
+import Link from '../../../common/views/containers/link';
 
 const formatters = {
   name: {
     format: (name, est) => {
-      return <a href={`/establishment/${est.id}`}>{name}</a>;
+      return <Link page="establishment.dashboard" establishment={ est.id } label={name} />;
     }
   }
 };
@@ -17,7 +18,7 @@ const Index = props => (
   <Fragment>
     <header>
       <h2>&nbsp;</h2>
-      <h1><Snippet>pages.establishments</Snippet></h1>
+      <h1><Snippet>pages.establishment.list</Snippet></h1>
     </header>
     <SearchBar label={<Snippet>searchText</Snippet>} />
     <FilterSummary />

--- a/pages/place/list/views/index.jsx
+++ b/pages/place/list/views/index.jsx
@@ -69,7 +69,7 @@ const Places = ({
   <Fragment>
     <header>
       <h2>{name}</h2>
-      <h1><Snippet>pages.places</Snippet></h1>
+      <h1><Snippet>pages.place.list</Snippet></h1>
     </header>
     <FilterTable formatters={formatters} ExpandableRow={ExpandableRow} editable={true} />
   </Fragment>

--- a/pages/place/read/index.js
+++ b/pages/place/read/index.js
@@ -1,5 +1,5 @@
 const page = require('../../../lib/page');
-const schema = require('../schema');
+const { schema } = require('../schema');
 
 module.exports = settings => {
   const app = page({

--- a/pages/place/read/views/index.jsx
+++ b/pages/place/read/views/index.jsx
@@ -18,7 +18,7 @@ const Place = ({
       <div className="column-two-thirds">
         <header>
           <h2>{model.name}</h2>
-          <h1><Snippet>pages.places</Snippet></h1>
+          <h1><Snippet>pages.place.list</Snippet></h1>
           <dl>
             {
               fields.map(key =>

--- a/pages/profile/list/views/index.jsx
+++ b/pages/profile/list/views/index.jsx
@@ -7,6 +7,7 @@ import DataTable from '../../../common/views/containers/datatable';
 import Acronym from '../../../common/views/components/acronym';
 import Join from '../../../common/views/components/join';
 import Snippet from '../../../common/views/containers/snippet';
+import Link from '../../../common/views/containers/link';
 
 const joinAcronyms = data => {
   if (Array.isArray(data)) {
@@ -17,7 +18,7 @@ const joinAcronyms = data => {
 
 export const formatters = {
   name: {
-    format: (name, person) => <a href={`profile/${person.id}`}>{ name }</a>
+    format: (name, person) => <Link page="profile.view" profile={person.id} label={ name } />
   },
   roles: {
     format: data => joinAcronyms(data)
@@ -34,7 +35,7 @@ const People = ({
   <Fragment>
     <header>
       <h2>{name}</h2>
-      <h1><Snippet>pages.people</Snippet></h1>
+      <h1><Snippet>pages.profile.list</Snippet></h1>
     </header>
     <SearchBar label={<Snippet>searchText</Snippet>} />
     <LinkFilter prop="roles" formatter={filter => <Acronym>{filter}</Acronym>} />

--- a/pages/profile/view/tests/middleware.js
+++ b/pages/profile/view/tests/middleware.js
@@ -1,0 +1,4 @@
+module.exports = (req, res, next) => {
+  req.profile = 'abc-123';
+  next();
+};

--- a/pages/project/list/views/index.jsx
+++ b/pages/project/list/views/index.jsx
@@ -6,10 +6,11 @@ import SearchBar from '../../../common/views/containers/search';
 import FilterSummary from '../../../common/views/containers/filter-summary';
 import DataTable from '../../../common/views/containers/datatable';
 import Snippet from '../../../common/views/containers/snippet';
+import Link from '../../../common/views/containers/link';
 
 export const formatters = {
   licenceHolder: {
-    format: (name, row) => <a href={`profile/${row.licenceHolder.id}`}>{ name }</a>
+    format: (name, project) => <Link page="profile.view" profile={project.licenceHolder.id} label={ name } />
   },
   expiryDate: {
     format: date => <ExpiryDate date={date}/>
@@ -45,7 +46,7 @@ const Projects = ({
   <Fragment>
     <header>
       <h2>{name}</h2>
-      <h1><Snippet>pages.projects</Snippet></h1>
+      <h1><Snippet>pages.project.list</Snippet></h1>
     </header>
     <SearchBar label={<Snippet>searchText</Snippet>} />
     <FilterSummary />

--- a/test/functional/app/index.js
+++ b/test/functional/app/index.js
@@ -1,3 +1,4 @@
+const { set } = require('lodash');
 const ui = require('@asl/service/ui');
 const withuser = require('./withuser');
 const fixtures = require('../fixtures');
@@ -24,8 +25,17 @@ module.exports = () => {
 
   const pages = getPages();
 
+  const urls = Object.keys(pages).reduce((all, path) => {
+    const key = path.replace('pages/', '').split('/').join('.');
+    return set(all, key, `/${path}`);
+  }, {});
+
+  app.use((req, res, next) => {
+    set(res.locals, 'static.urls', urls);
+    next();
+  });
+
   Object.keys(pages).forEach(page => {
-    console.log(`Mounting ${page}`);
     app.use(`/${page}`, pages[page].middleware);
     app.use(`/${page}`, pages[page].router);
   });

--- a/test/functional/fixtures/index.js
+++ b/test/functional/fixtures/index.js
@@ -1,7 +1,8 @@
+const establishment = require('./establishment.json');
 const fixtures = [
   {
     url: /^\/establishments?\/[a-z0-9-]+$/,
-    response: require('./establishment.json')
+    response: establishment
   },
   {
     url: /^\/establishments?\/[a-z0-9-]+\/places?\/[a-z0-9-]+$/,
@@ -10,6 +11,10 @@ const fixtures = [
   {
     url: /^\/establishments?\/[a-z0-9-]+\/roles?$/,
     response: require('./nacwos.json')
+  },
+  {
+    url: /^\/establishments?\/[a-z0-9-]+\/profiles?\/[a-z0-9-]+$/,
+    response: require('./profile.json')
   }
 ];
 
@@ -18,5 +23,10 @@ module.exports = url => {
     return r || (url.match(fixture.url) && fixture.response);
   }, null);
 
-  return Promise.resolve({ json: { data, meta: {} } });
+  return Promise.resolve({
+    json: {
+      data,
+      meta: { establishment }
+    }
+  });
 };

--- a/test/functional/fixtures/profile.json
+++ b/test/functional/fixtures/profile.json
@@ -1,0 +1,20 @@
+{
+  "name": "Leonard Martin",
+  "id": "8a85de80-5f33-11e8-91cd-c7ceba8eb031",
+  "migrated_id": "elh_8201",
+  "title": "Dr",
+  "firstName": "Leonard",
+  "lastName": "Martin",
+  "dob": "1970-04-23",
+  "position": "University Vice-Chancellor",
+  "qualifications": "BLib",
+  "certifications": null,
+  "address": "University of Croydon",
+  "postcode": "CR0 2YF",
+  "email": "vice-chancellor@croydon.ac.uk",
+  "telephone": "01840 345 678",
+  "notes": "",
+  "createdAt": "2018-05-24T09:19:20.681Z",
+  "updatedAt": "2018-05-24T09:19:20.681Z",
+  "establishmentId": "8201"
+}


### PR DESCRIPTION
Instead of assuming a common url pattern across all implementations, use a url map passed to the parent app (and exposed on `res.locals.static.urls`) to go from a page key (which correspond to the folder/router structure exposed by this module) and optional parameters to build urls.

Also maps the page title content snippets to use the same structure as everything else in order to make the establishment dashboard work nicely.