### PR TITLE
Use margins instead of text-indent

### DIFF
--- a/pages/common/assets/sass/_datatable.scss
+++ b/pages/common/assets/sass/_datatable.scss
@@ -105,12 +105,12 @@
 
     a {
       display: block;
-      text-indent: $gutter;
+      margin-left: $gutter;
       margin-bottom: 0.5em;
     }
 
     dl {
-      text-indent: $gutter-half;
+      margin-left: $gutter-half;
     }
   }
 }


### PR DESCRIPTION
text-indent only applies to the first line of text, so multiline restrictions end up looking out of whack.