### PR TITLE
Fix react PropType warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6274,9 +6274,9 @@
       }
     },
     "govuk-react-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-react-components/-/govuk-react-components-1.0.0.tgz",
-      "integrity": "sha512-PyMEANlwdCCNGDoqGmAuxC2X800CH7MJyQNfEpRrhkNR9o633Nco6ewAIinXRMpo9grwD4DbsSBi3vKsDJMp7A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-react-components/-/govuk-react-components-1.1.0.tgz",
+      "integrity": "sha512-D1E5Uk8gq8BBbNZ05smiPW9M8F8nWFsAXMcalcL5Jm7DCeV8WR9lycWxfbRh5iPXc43iiCtBOwqCWC7GE5Zgkw==",
       "requires": {
         "govuk_frontend_toolkit": "^7.5.0",
         "govuk_template_mustache": "^0.23.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.16.3",
     "find-root": "^1.1.0",
     "govuk-elements-sass": "^3.1.2",
-    "govuk-react-components": "^1.0.0",
+    "govuk-react-components": "^1.1.0",
     "govuk_frontend_toolkit": "^7.4.1",
     "lodash": "^4.17.5",
     "minimatch": "^3.0.4",

--- a/pages/common/views/components/form.jsx
+++ b/pages/common/views/components/form.jsx
@@ -6,15 +6,15 @@ import Snippet from '../containers/snippet';
 import ConditionalReveal from './conditional-reveal';
 
 const fields = {
-  inputText: ({ ...props }) => <Input { ...props } />,
-  textarea: ({ value, ...props }) => <TextArea value={value} { ...props } />,
-  radioGroup: ({ ...props }) => <RadioGroup { ...props } />,
-  checkboxGroup: ({ ...props }) => <RadioGroup type="checkbox" { ...props } />,
-  select: ({ ...props }) => <Select { ...props } />,
+  inputText: props => <Input { ...props } />,
+  textarea: props => <TextArea { ...props } />,
+  radioGroup: props => <RadioGroup { ...props } />,
+  checkboxGroup: props => <RadioGroup type="checkbox" { ...props } />,
+  select: props => <Select { ...props } />,
   text: props => props.value &&
     <div className="form-group">
       <h3>{ props.label }</h3>
-      <ReactMarkdown>{props.value }</ReactMarkdown>
+      <ReactMarkdown>{ props.value }</ReactMarkdown>
     </div>
 };
 

--- a/pages/common/views/components/snippet.jsx
+++ b/pages/common/views/components/snippet.jsx
@@ -12,12 +12,14 @@ const Snippet = ({ content, children, optional, ...props }) => {
     throw new Error(`Failed to lookup content snippet: ${children}`);
   }
   const source = render(str, props);
-  return <ReactMarkdown
-    source={source}
-    renderers={{ root: Fragment }}
-    allowNode={(node, index, parent) => parent.type !== 'root'}
-    unwrapDisallowed={true}
-  />;
+  return (
+    <ReactMarkdown
+      source={source}
+      renderers={{ root: Fragment }}
+      allowNode={(node, index, parent) => parent.type !== 'root'}
+      unwrapDisallowed={true}
+    />
+  );
 };
 
 export default Snippet;

--- a/pages/common/views/containers/form.jsx
+++ b/pages/common/views/containers/form.jsx
@@ -9,7 +9,6 @@ const extendSchema = (field, formatter) => {
   }
   return {
     ...field,
-    ...formatter,
     options: formatter.mapOptions ? field.options.map(formatter.mapOptions) : field.options,
     showIf: formatter.showIf
   };

--- a/pages/place/delete/views/index.jsx
+++ b/pages/place/delete/views/index.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import Snippet from '../../../common/views/containers/snippet';
 import ModelSummary from '../../../common/views/containers/model-summary';
-import Textarea from 'govuk-react-components/components/forms/textarea';
+import { TextArea } from 'govuk-react-components';
 import FormControls from '../../../common/views/components/form-controls';
 import formatters from '../../formatters';
 
@@ -20,7 +20,7 @@ const DeletePage = ({
         <hr />
         <form method="post">
           <input type="hidden" name="delete" value="true" />
-          <Textarea
+          <TextArea
             label={<Snippet>fields.comments.label</Snippet>}
             value={model.comments}
             name="comments"

--- a/pages/place/update/views/confirm.jsx
+++ b/pages/place/update/views/confirm.jsx
@@ -92,7 +92,7 @@ const Confirm = ({
                   label=""
                   options={[
                     {
-                      value: true,
+                      value: 'true',
                       label: <Snippet>declaration</Snippet>
                     }
                   ]}


### PR DESCRIPTION
* updated govuk-react-components to 1.1.0 - this includes support for elements as label, error and hint props
* use correct exported TextArea in delete view