### PR TITLE
Make column headings dynamic

### DIFF
--- a/pages/common/views/containers/datatable.jsx
+++ b/pages/common/views/containers/datatable.jsx
@@ -1,4 +1,4 @@
-import { merge, pickBy } from 'lodash';
+import { merge, pickBy, get } from 'lodash';
 import { connect } from 'react-redux';
 import { applyFilters, getSortedData } from '../../../../lib/reducers/datatable';
 import DataTable from '../components/datatable';
@@ -9,13 +9,17 @@ const mapStateToProps = ({
 }, {
   formatters
 }) => {
+  const existsInData = (key, accessor) => {
+    accessor = accessor || key;
+    return !!data.find(row => get(row, accessor));
+  };
   return {
     data: getSortedData({
       data: applyFilters({ data, filters, schema }),
       schema,
       sort
     }),
-    schema: pickBy(merge({}, schema, formatters), item => item.show),
+    schema: pickBy(merge({}, schema, formatters), (item, key) => item.show && existsInData(key, item.accessor)),
     sort
   };
 };


### PR DESCRIPTION
This will hide columns in datatables if no row in the entire dataset has a value in that field.

For example, we won't put the "area" column in the schedule of premises if no single row in the dataset (unfiltered) has an area defined.