### PR TITLE
Removed NACWO link in diff table

### DIFF
--- a/pages/place/formatters/index.jsx
+++ b/pages/place/formatters/index.jsx
@@ -1,7 +1,5 @@
-import React from 'react';
 import { get } from 'lodash';
 import { defineValue, joinAcronyms, labelFromCode } from '../../common/formatters';
-import Link from '../../common/views/containers/link';
 
 export default {
   suitability: {
@@ -15,7 +13,7 @@ export default {
     mapOptions: labelFromCode
   },
   nacwo: {
-    format: val => val && <Link page="profile.view" profile={ get(val, 'profile.id') } label={ get(val, 'profile.name') } />,
+    format: val => get(val, 'profile.name'),
     accessor: 'id'
   }
 };

--- a/pages/place/list/views/index.jsx
+++ b/pages/place/list/views/index.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import ReactMarkdown from 'react-markdown';
@@ -6,6 +7,7 @@ import FilterTable from '../../../common/views/components/filter-table';
 import Snippet from '../../../common/views/containers/snippet';
 import Controls from '../../../common/views/containers/controls';
 import formatters from '../../formatters';
+import Link from '../../../common/views/containers/link';
 
 const pageFormatters = {
   name: {
@@ -21,6 +23,9 @@ const pageFormatters = {
         </Fragment>
       );
     }
+  },
+  nacwo: {
+    format: val => val && <Link page="profile.view" profile={ get(val, 'profile.id') } label={ get(val, 'profile.name') } />
   }
 };
 


### PR DESCRIPTION
If we are viewing a diff of changes we don't want to include a link to the NACWO profile - this is because the user is in an edit journey