### PR TITLE
Remove export links from tables

### DIFF
--- a/pages/common/views/components/filter-table.jsx
+++ b/pages/common/views/components/filter-table.jsx
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react';
 import DataTable from '../containers/datatable';
 import Filters from '../containers/filters';
-import ExportLink from '../containers/export-link';
 import FilterSummary from '../containers/filter-summary';
 import Link from '../containers/link';
 import Snippet from '../containers/snippet';
@@ -20,7 +19,6 @@ const FilterTable = ({
       }
     </div>
     <DataTable formatters={ formatters } ExpandableRow={ExpandableRow} />
-    <ExportLink />
   </Fragment>
 );
 


### PR DESCRIPTION
They don't work, they can go back again when/if they do work or there are requirements.