### PR TITLE
Add a "loading" class to tables that are being refreshed

### DIFF
--- a/pages/common/views/components/datatable.jsx
+++ b/pages/common/views/components/datatable.jsx
@@ -42,10 +42,12 @@ class Table extends Component {
       data = [],
       schema,
       sortable,
+      isFetching,
       ExpandableRow
     } = this.props;
+
     return (
-      <table className="govuk-react-datatable">
+      <table className={classnames('govuk-react-datatable', isFetching && 'loading')}>
         <thead>
           <tr>
             {

--- a/pages/common/views/containers/datatable.jsx
+++ b/pages/common/views/containers/datatable.jsx
@@ -4,13 +4,14 @@ import DataTable from '../components/datatable';
 
 const mapStateToProps = ({
   static: { schema },
-  datatable: { data: { rows }, filters, sort }
+  datatable: { data: { rows, isFetching }, filters, sort }
 }, {
   formatters
 }) => {
   return {
     sort,
     data: rows,
+    isFetching,
     schema: pickBy(merge({}, schema, formatters), (item, key) => item.show)
   };
 };


### PR DESCRIPTION
While a datatable component is in a loading state then add a class to the top-level `<table>` component to indicate this fact.

Note that no styles have been bound to this class yet.