### PR TITLE
Reset pagination state when changing filters

### DIFF
--- a/lib/reducers/pagination.js
+++ b/lib/reducers/pagination.js
@@ -21,6 +21,9 @@ const pagination = (state = INITIAL_STATE, action) => {
     state = { ...INITIAL_STATE, ...state, hydrated: true };
   }
   switch (action.type) {
+    case 'SET_FILTER':
+    case 'SET_FILTERS':
+      return paginate({ ...state, page: INITIAL_STATE.page });
     case 'SET_PAGE':
       return paginate({ ...state, page: action.page });
     case 'RECEIVE_ITEMS':


### PR DESCRIPTION
We want to go back to page 1 (or 0) when we filter an existing data table. Otherwise weird things happen like we say we're showing 21-5 of 5 records.