### PR TITLE
Fix bug with pagination control page numbers

### DIFF
--- a/pages/common/views/components/pagination.jsx
+++ b/pages/common/views/components/pagination.jsx
@@ -9,7 +9,11 @@ const PaginationControls = ({
   count,
   onPageChange
 }) => {
-  const numberLinks = totalPages < 5 ? totalPages : 5;
+  const pagesToShow = () => {
+    const end = Math.min(totalPages, Math.max(5, page + 3));
+    const start = Math.max(0, end - 5);
+    return Array.from(Array(totalPages).keys()).slice(start, end);
+  };
   const links = [
     {
       ariaLabel: 'Previous page',
@@ -18,11 +22,11 @@ const PaginationControls = ({
       target: (page - 1) || 0,
       disabled: page <= 0
     },
-    ...Array.from(Array(numberLinks + 1).keys()).slice(1).map(p => ({
-      ariaLabel: `Page ${p}`,
-      label: p,
-      target: p - 1,
-      disabled: page + 1 === p
+    ...pagesToShow().map(p => ({
+      ariaLabel: `Page ${p + 1}`,
+      label: p + 1,
+      target: p,
+      disabled: page === p
     })),
     {
       ariaLabel: 'Next page',

--- a/test/functional/fixtures/index.js
+++ b/test/functional/fixtures/index.js
@@ -51,7 +51,11 @@ module.exports = url => {
   return Promise.resolve({
     json: {
       data,
-      meta: { establishment }
+      meta: {
+        establishment,
+        total: 50,
+        count: 50
+      }
     }
   });
 };

--- a/test/unit/views/components/pagination.spec.jsx
+++ b/test/unit/views/components/pagination.spec.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Pagination from '../../../../pages/common/views/components/pagination';
+import ApplyChanges from '../../../../pages/common/views/containers/apply-changes';
+
+describe('<Pagination />', () => {
+
+  test('renders 1-5 page links with the first selected when on page 1', () => {
+    const props = {
+      page: 0,
+      totalPages: 10,
+      limit: 10,
+      count: 96
+    };
+    const container = shallow(<Pagination {...props}/>);
+    const labels = container.find(ApplyChanges);
+    expect(labels.at(1).prop('label')).toBe(1);
+    expect(labels.at(2).prop('label')).toBe(2);
+    expect(labels.at(3).prop('label')).toBe(3);
+    expect(labels.at(4).prop('label')).toBe(4);
+    expect(labels.at(5).prop('label')).toBe(5);
+    expect(labels.at(1).prop('className')).toContain('current');
+    expect(labels.at(2).prop('className')).not.toContain('current');
+    expect(labels.at(3).prop('className')).not.toContain('current');
+    expect(labels.at(4).prop('className')).not.toContain('current');
+    expect(labels.at(5).prop('className')).not.toContain('current');
+  });
+
+  test('renders 3-7 page links with the middle page selected when on page 5 of 10', () => {
+    const props = {
+      page: 4,
+      totalPages: 10,
+      limit: 10,
+      count: 96
+    };
+    const container = shallow(<Pagination {...props}/>);
+    const labels = container.find(ApplyChanges);
+    expect(labels.at(1).prop('label')).toBe(3);
+    expect(labels.at(2).prop('label')).toBe(4);
+    expect(labels.at(3).prop('label')).toBe(5);
+    expect(labels.at(4).prop('label')).toBe(6);
+    expect(labels.at(5).prop('label')).toBe(7);
+    expect(labels.at(1).prop('className')).not.toContain('current');
+    expect(labels.at(2).prop('className')).not.toContain('current');
+    expect(labels.at(3).prop('className')).toContain('current');
+    expect(labels.at(4).prop('className')).not.toContain('current');
+    expect(labels.at(5).prop('className')).not.toContain('current');
+  });
+
+  test('renders 6-10 page links with the last page selected when on page 10 of 10', () => {
+    const props = {
+      page: 9,
+      totalPages: 10,
+      limit: 10,
+      count: 96
+    };
+    const container = shallow(<Pagination {...props}/>);
+    const labels = container.find(ApplyChanges);
+    expect(labels.at(1).prop('label')).toBe(6);
+    expect(labels.at(2).prop('label')).toBe(7);
+    expect(labels.at(3).prop('label')).toBe(8);
+    expect(labels.at(4).prop('label')).toBe(9);
+    expect(labels.at(5).prop('label')).toBe(10);
+    expect(labels.at(1).prop('className')).not.toContain('current');
+    expect(labels.at(2).prop('className')).not.toContain('current');
+    expect(labels.at(3).prop('className')).not.toContain('current');
+    expect(labels.at(4).prop('className')).not.toContain('current');
+    expect(labels.at(5).prop('className')).toContain('current');
+  });
+
+});


### PR DESCRIPTION
When going past page 3 the page numbers in the control should show the current page with 2 pages either side. Previously only pages 1-5 were ever shown.