### PR TITLE
Prevent status bar trying to load user on error pages

### DIFF
--- a/pages/common/views/layouts/default.jsx
+++ b/pages/common/views/layouts/default.jsx
@@ -39,7 +39,7 @@ const Layout = ({
       propositionHeader={siteTitle}
       stylesheets={['/public/css/app.css']}
       scripts={['/public/js/common/bundle.js'].concat(scripts)}
-      headerContent={<StatusBar user={user} />}
+      headerContent={<StatusBar user={wrap ? user : {}} />}
       nonce={nonce}
     >
       <main className="main" id="content">


### PR DESCRIPTION
The user menu requires a redux provider to render, which is not applied in error pages. Pass an empty user object to the status bar in the case where an error page is rendered.