### PR TITLE
Omit `declaration` property from API submissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,15 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -175,6 +184,12 @@
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "dev": true
     },
     "@types/node": {
       "version": "10.3.3",
@@ -8455,9 +8470,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
       "dev": true
     },
     "jwk-to-pem": {
@@ -8911,9 +8926,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
+      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
       "dev": true
     },
     "long": {
@@ -9564,13 +9579,13 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
+      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
+        "just-extend": "^3.0.0",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
@@ -11327,6 +11342,32 @@
       "requires": {
         "express": "^4.15.2",
         "sinon": "^4.0.0"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+          "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "diff": "^3.1.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.2.0",
+            "nise": "^1.2.0",
+            "supports-color": "^5.1.0",
+            "type-detect": "^4.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "request": {
@@ -12293,24 +12334,26 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
+      "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
       "dev": true,
       "requires": {
+        "@sinonjs/commons": "^1.0.1",
         "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
+        "@sinonjs/samsam": "^2.0.0",
+        "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "lolex": "^2.7.1",
+        "nise": "^1.4.2",
+        "supports-color": "^5.4.0",
+        "type-detect": "^4.0.8"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mkdirp": "^0.5.1",
     "npm-sass": "^2.2.3",
     "reqres": "^2.1.0",
+    "sinon": "^6.1.5",
     "supertest": "^3.1.0",
     "wdio-mocha-framework": "^0.5.13",
     "webdriverio": "^4.12.0",

--- a/pages/place/create/index.js
+++ b/pages/place/create/index.js
@@ -1,3 +1,5 @@
+const { omit } = require('lodash');
+
 const page = require('../../../lib/page');
 const amend = require('../routers/amend');
 const confirm = require('../routers/confirm');
@@ -36,7 +38,7 @@ module.exports = settings => {
   });
 
   app.post('/confirm', (req, res, next) => {
-    const values = req.session.form[req.model.id].values;
+    const values = omit(req.session.form[req.model.id].values, 'declaration');
     const opts = {
       method: 'POST',
       headers: { 'Content-type': 'application/json' },

--- a/pages/place/update/index.js
+++ b/pages/place/update/index.js
@@ -1,3 +1,5 @@
+const { omit } = require('lodash');
+
 const page = require('../../../lib/page');
 const confirm = require('../routers/confirm');
 const amend = require('../routers/amend');
@@ -35,7 +37,7 @@ module.exports = settings => {
   app.use('/confirm', confirm());
 
   app.post('/confirm', (req, res, next) => {
-    const values = req.session.form[req.model.id].values;
+    const values = omit(req.session.form[req.model.id].values, 'declaration');
     const opts = {
       method: 'PUT',
       headers: { 'Content-type': 'application/json' },

--- a/test/unit/pages/place/routers/create.spec.js
+++ b/test/unit/pages/place/routers/create.spec.js
@@ -1,0 +1,41 @@
+import reqres from 'reqres';
+import sinon from 'sinon';
+import form from '../../../../../pages/place/create';
+
+describe('Create Router', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+
+  describe('POST /confirm', () => {
+
+    beforeEach(() => {
+      req.method = 'post';
+      req.path = '/confirm';
+      req.model = { id: 'abc-123' };
+      req.session = {
+        'abc123': {
+          values: {
+            name: 'name',
+            site: 'site',
+            declaration: 'true'
+          }
+        }
+      };
+      req.api = sinon.stub().returns(Promise.resolve());
+    });
+
+    it('removes `declaration` property from form values', () => {
+      form(req, res, () => {
+        expect(req.api.calledOnce).toBe(true);
+        const payload = req.api.lastCall.args[1].body;
+        expect(payload).toEqual(JSON.stringify({ name: 'name', site: 'site' }));
+      });
+    });
+
+  });
+});

--- a/test/unit/pages/place/routers/update.spec.js
+++ b/test/unit/pages/place/routers/update.spec.js
@@ -1,0 +1,41 @@
+import reqres from 'reqres';
+import sinon from 'sinon';
+import form from '../../../../../pages/place/update';
+
+describe('Update Router', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+
+  describe('POST /confirm', () => {
+
+    beforeEach(() => {
+      req.method = 'post';
+      req.path = '/confirm';
+      req.model = { id: 'abc-123' };
+      req.session = {
+        'abc123': {
+          values: {
+            name: 'name',
+            site: 'site',
+            declaration: 'true'
+          }
+        }
+      };
+      req.api = sinon.stub().returns(Promise.resolve());
+    });
+
+    it('removes `declaration` property from form values', () => {
+      form(req, res, () => {
+        expect(req.api.calledOnce).toBe(true);
+        const payload = req.api.lastCall.args[1].body;
+        expect(payload).toEqual(JSON.stringify({ name: 'name', site: 'site' }));
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
The declaration property is not used downstream anywhere, so there's no point in sending it. Especially given that it causes API json schema validation to fail.