### PR TITLE
Fix markdown rendering in snippet components

### DIFF
--- a/pages/common/views/components/snippet.jsx
+++ b/pages/common/views/components/snippet.jsx
@@ -13,15 +13,15 @@ const Snippet = ({ content, children, optional, ...props }) => {
   if (str === undefined) {
     throw new Error(`Failed to lookup content snippet: ${children}`);
   }
-  const source = render(str, props);
+  const source = trim(render(str, props));
 
   const isRootParagraph = (node, i, parent) => {
     return node.type !== 'paragraph' || parent.type !== 'root' || parent.children.length !== 1;
-  }
+  };
 
   return (
     <ReactMarkdown
-      source={trim(source)}
+      source={source}
       renderers={{ root: Fragment }}
       allowNode={isRootParagraph}
       unwrapDisallowed={true}

--- a/pages/common/views/components/snippet.jsx
+++ b/pages/common/views/components/snippet.jsx
@@ -3,6 +3,8 @@ import React, { Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { render } from 'mustache';
 
+const trim = value => value.split('\n').map(s => s.trim()).join('\n').trim();
+
 const Snippet = ({ content, children, optional, ...props }) => {
   const str = get(content, children);
   if (str === undefined && optional) {
@@ -12,11 +14,16 @@ const Snippet = ({ content, children, optional, ...props }) => {
     throw new Error(`Failed to lookup content snippet: ${children}`);
   }
   const source = render(str, props);
+
+  const isRootParagraph = (node, i, parent) => {
+    return node.type !== 'paragraph' || parent.type !== 'root' || parent.children.length !== 1;
+  }
+
   return (
     <ReactMarkdown
-      source={source}
+      source={trim(source)}
       renderers={{ root: Fragment }}
-      allowNode={(node, index, parent) => parent.type !== 'root'}
+      allowNode={isRootParagraph}
       unwrapDisallowed={true}
     />
   );

--- a/test/unit/views/components/snippet.spec.jsx
+++ b/test/unit/views/components/snippet.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from 'enzyme';
+import Snippet from 'views/components/snippet';
+
+describe('<Snippet />', () => {
+
+  const content = {
+    string: 'one line',
+    list: `* one
+      * two
+      * three`,
+    paragraphs: `one
+
+      two`
+  };
+
+  test('does not include a wrapping element on single line input', () => {
+    const wrapper = render(<div><Snippet content={content}>string</Snippet></div>);
+    expect(wrapper.find('p').length).toEqual(0);
+    expect(wrapper.text()).toEqual('one line');
+  });
+
+  test('includes wrapping elements on list inputs inputs', () => {
+    const wrapper = render(<div><Snippet content={content}>list</Snippet></div>);
+    expect(wrapper.find('ul').length).toEqual(1);
+    expect(wrapper.text()).toEqual('onetwothree');
+  });
+
+  test('includes wrapping elements on multi-line paragraph inputs', () => {
+    const wrapper = render(<div><Snippet content={content}>paragraphs</Snippet></div>);
+    expect(wrapper.find('p').length).toEqual(2);
+    expect(wrapper.text()).toEqual('onetwo');
+  });
+
+});


### PR DESCRIPTION
Trims any leading whitespace from multiline content

Allows wrapper nodes in cases where the wrapper node is not the _only_ <p> tag - i.e. in cases where it's not a single-line string.