### PR TITLE
AS-679: Exclude buttons from link focus styling

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -134,7 +134,7 @@ th {
       border: 1px solid govuk-colour('grey-1');
       padding: $govuk-gutter;
 
-      a {
+      a:not(.govuk-button) {
         &:focus {
           background-color: $highlight-colour;
           outline: none;
@@ -303,7 +303,7 @@ dl.inline {
 }
 
 .status-label {
-  display: inline-block;
+  display: block;
   float: right;
   padding: 0 6px;
   text-transform: uppercase;


### PR DESCRIPTION
Links styled as buttons in dashboard list items were disappearing when clicked do to focus styling inherited from the links.