### PR TITLE
Expose all allowed actions to client

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -51,13 +51,19 @@ module.exports = ({
       : req.baseUrl;
 
     const filename = req.path.replace('/', '') || 'index';
+
+    const allowedActions = []
+      .concat(req.user.profile.allowedActions.global)
+      .concat(req.user.profile.allowedActions[req.establishment])
+      .filter(Boolean);
+
     Object.assign(res.locals, {
       scripts: [`/public/js/${pagePath}/${filename}/bundle.js`],
       rootReducer: combineReducers(rootReducer),
       static: Object.assign(res.locals.static, {
         url,
-        content: merge({}, res.locals.static.content, pages[req.path].content, content),
-        allowedActions: req.user.profile.allowedActions[req.establishment]
+        allowedActions,
+        content: merge({}, res.locals.static.content, pages[req.path].content, content)
       })
     });
 


### PR DESCRIPTION
Some users obtain permissions based on global properties (i.e. inspectors and other ASRU users) so ensure the client has access to all the actions a user can carry out, and not just those inherited from an establishment.