### PR TITLE
Use `req.user.can` for determining permissions in middleware

### DIFF
--- a/lib/middleware/permissions.js
+++ b/lib/middleware/permissions.js
@@ -1,8 +1,12 @@
 module.exports = task => (req, res, next) => {
-  if (req.user.isAllowed(task)) {
-    return next();
-  }
-  const err = new Error('Unauthorised');
-  err.status = 401;
-  next(err);
+  req.user.can(task, { ...req.params, establishment: req.establishment })
+    .then(allowed => {
+      if (allowed) {
+        return next();
+      }
+      const err = new Error('Unauthorised');
+      err.status = 401;
+      throw err;
+    })
+    .catch(next);
 };


### PR DESCRIPTION
We effectively have two functions at the moment which perform the exact same action in two different ways. Standardise on one of those.