### PR TITLE
AS-666: defining an accessor when value is not object breaks the select input

### DIFF
--- a/pages/pil/certificate/schema/index.js
+++ b/pages/pil/certificate/schema/index.js
@@ -11,7 +11,6 @@ module.exports = {
   accreditingBody: {
     inputType: 'select',
     options: accreditingBodies,
-    accessor: 'id',
     validate: [
       'required',
       {


### PR DESCRIPTION
An accessor should only be specified for a form field when the value in the model is an object.

For string values, just omit the accessor.