### PR TITLE
AS-732: use correct profile for PIL links

### DIFF
--- a/pages/pil/categories/index.js
+++ b/pages/pil/categories/index.js
@@ -9,7 +9,7 @@ module.exports = settings => {
   app.use('/', (req, res, next) => {
     const establishment = req.user.profile.establishments.find(e => e.id === req.establishmentId);
     res.locals.static.establishment = establishment;
-    res.locals.static.profile = req.user.profile;
+    res.locals.static.profile = req.profile;
     res.locals.static.pilApplication = {
       id: 'create'
     };

--- a/pages/pil/categories/views/index.jsx
+++ b/pages/pil/categories/views/index.jsx
@@ -20,7 +20,7 @@ const Index = ({ establishment, pilApplication, profile }) => (
               <li key={link}>
                 <h2>
                   <Link
-                    page="pil.dashboard"
+                    page="pil.application"
                     profile={profile.id}
                     pil={pilApplication.id}
                     label={<Snippet>{`${link}.title`}</Snippet>}


### PR DESCRIPTION
The links were using the currently signed in profile id rather than the profile id in the url.