### PR TITLE
Allow error pages to render if no user is defined

### DIFF
--- a/pages/common/views/components/status-bar.jsx
+++ b/pages/common/views/components/status-bar.jsx
@@ -9,7 +9,7 @@ class StatusBar extends Component {
     } = this.props;
     return (
       <div className="status-bar">
-        { user.profile && (
+        { user && user.profile && (
           <Fragment>
             <span><a href="/profile">{user.profile.name}</a></span>
             |


### PR DESCRIPTION
There are some error cases - missing session store or failed auth - where the user isn't defined at all, and so errors are swallowed by "cannot read property 'profile' of undefined".