### PR TITLE
Check link is a string instead of only truthiness

### DIFF
--- a/pages/common/views/components/link.jsx
+++ b/pages/common/views/components/link.jsx
@@ -16,7 +16,7 @@ const Link = ({
 }) => {
   if (page) {
     const href = get(urls, page);
-    if (!href) {
+    if (typeof href !== 'string') {
       throw new Error(`Unknown link target: ${page}`);
     }
     const replacer = replace(props);


### PR DESCRIPTION
We can't do anything later if it's not a string, and there's misconfiguration cases where it can easily resolve to a "not string" that currently throw an opaque error - "href.split is not a function"