### PR TITLE
Support pages which don't have a logged-in user

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -54,21 +54,24 @@ module.exports = ({
 
     const filename = req.path.replace('/', '') || 'index';
 
-    const allowedActions = []
-      .concat(req.user.profile.allowedActions.global)
-      .concat(req.user.profile.allowedActions[req.establishmentId])
-      .filter(Boolean);
-
     Object.assign(res.locals, {
       scripts: [`/public/js/${pagePath}/${filename}/bundle.js`],
       rootReducer: combineReducers(rootReducer),
       static: Object.assign(res.locals.static, {
         url,
-        allowedActions,
+        allowedActions: [],
         content: merge({}, res.locals.static.content, pages[req.path].content, content),
         ...req.params
       })
     });
+
+    if (req.user && req.user.profile) {
+      const allowedActions = []
+        .concat(req.user.profile.allowedActions.global)
+        .concat(req.user.profile.allowedActions[req.establishmentId])
+        .filter(Boolean);
+      res.locals.static.allowedActions = allowedActions;
+    }
 
     res.template = pages[req.path].template;
     return next();


### PR DESCRIPTION
In particular, pages in the register service, where a user session has not been created. These currently crash with an error on this code.