### PR TITLE
Fix redirect url parameters

### DIFF
--- a/lib/middleware/route-builder.js
+++ b/lib/middleware/route-builder.js
@@ -1,7 +1,13 @@
 const { get } = require('lodash');
 
 const replace = params => fragment => {
-  return fragment[0] === ':' ? params[fragment.substr(1)] : fragment;
+  if (fragment[0] === ':') {
+    if (!params[fragment.substr(1)]) {
+      throw new Error(`URL Builder: undefined parameter: "${fragment}"`);
+    }
+    return params[fragment.substr(1)];
+  }
+  return fragment;
 };
 
 module.exports = () => (req, res, next) => {

--- a/pages/place/create/index.js
+++ b/pages/place/create/index.js
@@ -23,7 +23,7 @@ module.exports = settings => {
   }));
 
   app.post('/', (req, res, next) => {
-    return res.redirect(req.buildRoute('place.create.confirm', {establishment: req.establishmentId}));
+    return res.redirect(req.buildRoute('place.create.confirm'));
   });
 
   app.use('/confirm', confirm());
@@ -61,7 +61,7 @@ module.exports = settings => {
   });
 
   app.post('/confirm', (req, res, next) => {
-    return res.redirect(req.buildRoute('place.create.success', {establishment: req.establishmentId}));
+    return res.redirect(req.buildRoute('place.create.success'));
   });
 
   app.use('/success', success({ model: 'place' }));

--- a/pages/place/delete/index.js
+++ b/pages/place/delete/index.js
@@ -31,8 +31,7 @@ module.exports = settings => {
   }));
 
   app.post('/', (req, res, next) => {
-    const { id } = req.model;
-    return res.redirect(req.buildRoute('place.delete.confirm', {establishment: req.establishmentId, id}));
+    return res.redirect(req.buildRoute('place.delete.confirm', { placeId: req.model.id }));
   });
 
   app.use('/confirm', confirm());
@@ -53,8 +52,7 @@ module.exports = settings => {
   });
 
   app.post('/confirm', (req, res, next) => {
-    const {id} = req.model;
-    return res.redirect(req.buildRoute('place.delete.success', {establishment: req.establishmentId, id}));
+    return res.redirect(req.buildRoute('place.delete.success', { placeId: req.model.id }));
   });
 
   app.use('/success', successRouter({ model: 'place' }));

--- a/pages/place/update/index.js
+++ b/pages/place/update/index.js
@@ -31,8 +31,7 @@ module.exports = settings => {
   }));
 
   app.post('/', (req, res, next) => {
-    const { id } = req.model;
-    return res.redirect(req.buildRoute('place.update.confirm', {id}));
+    return res.redirect(req.buildRoute('place.update.confirm', { placeId: req.model.id }));
   });
 
   app.use('/confirm', confirm());
@@ -62,8 +61,7 @@ module.exports = settings => {
   });
 
   app.post('/confirm', (req, res, next) => {
-    const { id } = req.model;
-    return res.redirect(req.buildRoute('place.update.success', {id}));
+    return res.redirect(req.buildRoute('place.update.success', { placeId: req.model.id }));
   });
 
   app.use('/success', success({ model: 'place' }));


### PR DESCRIPTION
The wrong parameters are being passed in some cases to the url builder, which means pages are 404-ing.

