### PR TITLE
Add breadcrumbs to pages

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -2,8 +2,9 @@ const { merge } = require('lodash');
 const { combineReducers } = require('redux');
 const path = require('path');
 const findRoot = require('find-root');
-const express = require('express');
+const { Router } = require('express');
 const rootReducer = require('./reducers');
+const routeBuilder = require('./middleware/route-builder');
 
 const lookup = (...args) => {
   if (!args.length) {
@@ -18,13 +19,14 @@ const lookup = (...args) => {
 
 module.exports = ({
   root,
+  crumbs = [],
   paths = [],
   content = {},
   contentPath = '../content'
 }) => {
-  const app = express.Router({ mergeParams: true });
+  const app = Router({ mergeParams: true });
 
-  app.use(require('./middleware/route-builder')());
+  app.use(routeBuilder());
 
   // always serve on slash
   paths.unshift('/');
@@ -72,7 +74,6 @@ module.exports = ({
         .filter(Boolean);
       res.locals.static.allowedActions = allowedActions;
     }
-
     res.template = pages[req.path].template;
     return next();
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-1.6.0.tgz",
-      "integrity": "sha1-FEtaX+iN7kuAFgGTeuZgexHgM2g=",
+      "version": "2.0.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-2.0.0.tgz",
+      "integrity": "sha1-SX0isPdyYFJpmPx63EiLgobTI6k=",
       "requires": {
         "@asl/dictionary": "^1.1.1",
         "@ukhomeoffice/react-components": "^0.4.0",
@@ -30,9 +30,9 @@
           }
         },
         "hoist-non-react-statics": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
-          "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
+          "integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
           "requires": {
             "react-is": "^16.3.2"
           }
@@ -141,6 +141,98 @@
         "winston": "^2.4.2"
       },
       "dependencies": {
+        "@asl/components": {
+          "version": "1.6.0",
+          "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-1.6.0.tgz",
+          "integrity": "sha1-FEtaX+iN7kuAFgGTeuZgexHgM2g=",
+          "requires": {
+            "@asl/dictionary": "^1.1.1",
+            "@ukhomeoffice/react-components": "^0.4.0",
+            "classnames": "^2.2.6",
+            "date-fns": "^1.29.0",
+            "mustache": "^3.0.0",
+            "r2": "^2.0.1",
+            "react-addons-css-transition-group": "^15.6.2",
+            "react-markdown": "^4.0.3",
+            "react-redux": "^5.1.0",
+            "redux": "^4.0.1"
+          },
+          "dependencies": {
+            "mustache": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+              "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+            },
+            "react-redux": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+              "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+              "requires": {
+                "@babel/runtime": "^7.1.2",
+                "hoist-non-react-statics": "^3.1.0",
+                "invariant": "^2.2.4",
+                "loose-envify": "^1.1.0",
+                "prop-types": "^15.6.1",
+                "react-is": "^16.6.0",
+                "react-lifecycles-compat": "^3.0.0"
+              }
+            },
+            "redux": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+              "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "symbol-observable": "^1.2.0"
+              },
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                  "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                  "requires": {
+                    "js-tokens": "^3.0.0 || ^4.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@ukhomeoffice/react-components": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.4.0.tgz",
+          "integrity": "sha512-n3N5bJ+FoZjrBMYy4xNocqdwEEJ6u3gC06elL564IzIo2UGppistkdkoVFTTTUY9DpdHMCu32WjGCaiOYlpI/w==",
+          "requires": {
+            "classnames": "^2.2.6"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
+          "integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
+          "requires": {
+            "react-is": "^16.3.2"
+          }
+        },
+        "react-is": {
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+          "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+        },
+        "react-markdown": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.3.tgz",
+          "integrity": "sha512-CIc3eLVpW5XocM1MCid2rS0vs9skhvdL/slAkY/a3Cr9y72b0J/25GiD70fGmStjuxsd5ROdm4ZYfiYYxPPyGA==",
+          "requires": {
+            "html-to-react": "^1.3.3",
+            "mdast-add-list-metadata": "1.0.1",
+            "prop-types": "^15.6.1",
+            "remark-parse": "^5.0.0",
+            "unified": "^6.1.5",
+            "unist-util-visit": "^1.3.0",
+            "xtend": "^4.0.1"
+          }
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^1.6.0",
+    "@asl/components": "^2.0.0",
     "@asl/constants": "^0.3.1",
     "@asl/dictionary": "^1.1.1",
     "@asl/service": "^6.5.0",

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -1,6 +1,32 @@
 module.exports = {
   siteTitle: 'Research and testing with animals',
   beta: 'This is a new service - your [feedback](mailto:animalscience@digital.homeoffice.gov.uk) will help us to improve it.',
+  breadcrumbs: {
+    dashboard: 'Home',
+    invitation: 'Accept invitation',
+    establishment: {
+      dashboard: '{{establishment.name}}',
+      read: 'Details'
+    },
+    pil: {
+      base: 'Personal licence'
+    },
+    place: {
+      list: 'Licensed premises'
+    },
+    profile: {
+      list: 'People',
+      view: '{{model.firstName}} {{model.lastName}}'
+    },
+    project: {
+      list: 'Projects'
+    },
+    account: {
+      menu: 'Account',
+      edit: 'Edit'
+    },
+    feedback: 'Feedback'
+  },
   pages: {
     account: {
       title: 'Your account'

--- a/pages/establishment/details/index.js
+++ b/pages/establishment/details/index.js
@@ -7,6 +7,11 @@ module.exports = settings => {
     root: __dirname
   });
 
+  app.get('/', (req, res, next) => {
+    req.breadcrumb('establishment.read');
+    next();
+  });
+
   app.get('/',
     permissions('establishment.read'),
     (req, res, next) => {

--- a/pages/feedback/index.js
+++ b/pages/feedback/index.js
@@ -6,5 +6,10 @@ module.exports = settings => {
     root: __dirname
   });
 
+  app.get('/', (req, res, next) => {
+    req.breadcrumb('feedback');
+    next();
+  });
+
   return app;
 };

--- a/pages/pil/index.js
+++ b/pages/pil/index.js
@@ -1,5 +1,10 @@
 const { Router } = require('express');
 
+const create = require('./create');
+const read = require('./read');
+const update = require('./update');
+const remove = require('./delete');
+
 module.exports = () => {
   const app = Router({ mergeParams: true });
 
@@ -16,11 +21,15 @@ module.exports = () => {
       .catch(next);
   });
 
-  app.use('/:pilId/edit', require('./update')());
-  app.use('/:pilId/delete', require('./delete')());
-  app.use('/:pilId', require('./read')());
+  app.use((req, res, next) => {
+    req.breadcrumb('pil.base');
+    next();
+  });
 
-  app.use('/create', require('./create')());
+  app.use('/:pilId/edit', update());
+  app.use('/:pilId/delete', remove());
+  app.use('/:pilId', read());
+  app.use('/create', create());
 
   app.get('/', (req, res, next) => {
     res.redirect(req.buildRoute('pil.create'));

--- a/pages/pil/update/index.js
+++ b/pages/pil/update/index.js
@@ -3,6 +3,10 @@ const form = require('../../common/routers/form');
 const schema = require('./schema');
 const { get } = require('lodash');
 
+const procedures = require('../procedures');
+const exemptions = require('../exemptions');
+const training = require('../training');
+
 module.exports = settings => {
   const app = page({
     ...settings,
@@ -45,11 +49,11 @@ module.exports = settings => {
     next();
   });
 
-  app.use('/procedures', require('../procedures')());
+  app.use('/procedures', procedures());
 
-  app.use('/exemptions', require('../exemptions')());
+  app.use('/exemptions', exemptions());
 
-  app.use('/training', require('../training')());
+  app.use('/training', training());
 
   return app;
 };

--- a/pages/place/index.js
+++ b/pages/place/index.js
@@ -19,7 +19,8 @@ module.exports = () => {
       return next('route');
     }
     return req.api(`/establishment/${req.establishmentId}/place/${id}`)
-      .then(({ json: { data } }) => {
+      .then(({ json: { data, meta } }) => {
+        res.locals.static.establishment = meta.establishment;
         req.model = cleanModel(data);
       })
       .then(() => next())
@@ -28,6 +29,11 @@ module.exports = () => {
 
   app.use((req, res, next) => {
     res.locals.static.schema = schema;
+    next();
+  });
+
+  app.use((req, res, next) => {
+    req.breadcrumb('place.list');
     next();
   });
 

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -37,6 +37,11 @@ module.exports = () => {
       .catch(next);
   });
 
+  app.use((req, res, next) => {
+    req.breadcrumb('profile.list');
+    next();
+  });
+
   app.use('/:profileId', permissions('profile.read.basic'), read());
   app.use('/invite', permissions('profile.invite'), invite());
 

--- a/pages/profile/invite/index.js
+++ b/pages/profile/invite/index.js
@@ -2,7 +2,6 @@ const { set } = require('lodash');
 const page = require('../../../lib/page');
 const form = require('../../common/routers/form');
 const schema = require('./schema');
-const { crumbs } = require('@asl/service/ui/middleware');
 
 module.exports = settings => {
   const app = page({
@@ -11,11 +10,6 @@ module.exports = settings => {
   });
 
   app.use('/', form({ schema }));
-
-  app.use(crumbs([
-    { href: '{{{static.urls.profile.list}}}', label: '{{static.content.pages.profile.list}}' },
-    '{{static.content.pages.profile.invite}}'
-  ]));
 
   app.use('/', (req, res, next) => {
     const establishment = req.user.profile.establishments.find(e => e.id === req.establishmentId);

--- a/pages/profile/read/index.js
+++ b/pages/profile/read/index.js
@@ -7,6 +7,11 @@ module.exports = settings => {
   });
 
   app.get('/', (req, res, next) => {
+    req.breadcrumb('profile.view');
+    next();
+  });
+
+  app.get('/', (req, res, next) => {
     res.locals.static.isUser = req.user.profile.id === req.profileId;
     next();
   });

--- a/pages/project/list/index.js
+++ b/pages/project/list/index.js
@@ -9,6 +9,11 @@ module.exports = settings => {
     root: __dirname
   });
 
+  app.use((req, res, next) => {
+    req.breadcrumb('project.list');
+    next();
+  });
+
   app.use(datatable({
     configure: (req, res, next) => {
       req.datatable.sort = { column: 'expiryDate', ascending: true };

--- a/pages/user/account/views/index.jsx
+++ b/pages/user/account/views/index.jsx
@@ -10,7 +10,7 @@ const Index = () => {
     <Header title={<Snippet>pages.account.title</Snippet>} />
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        <ul className="dashboard">
+        <ul className="panel-list">
           <li>
             <Link page="account.edit" label={ <Snippet>pages.account.edit</Snippet> } />
           </li>

--- a/pages/user/index.js
+++ b/pages/user/index.js
@@ -16,6 +16,11 @@ module.exports = () => {
     next();
   });
 
+  router.use((req, res, next) => {
+    req.breadcrumb('account.menu');
+    next();
+  });
+
   router.use('/', account());
   router.use('/edit', update());
 

--- a/pages/user/update/index.js
+++ b/pages/user/update/index.js
@@ -27,6 +27,11 @@ module.exports = settings => {
     }
   }));
 
+  app.get('/', (req, res, next) => {
+    req.breadcrumb('account.edit');
+    next();
+  });
+
   app.post('/', (req, res, next) => {
     const values = req.session.form[req.model.id].values;
     const opts = {


### PR DESCRIPTION
This allows each page - or set of nested pages - to push their own breadcrumb elements onto the stack.

Also removed some inline requires and pull them to the top of files.

This doesn't touch any of the PIL bread-crumbing at the moment, because it's a bit of a Balrog. There needs to be some work around how and if we expose the owner of the PIL in the UI, because it currently isn't displayed, which is probably bad.