### PR TITLE
Redirect to invitations list following invite

### DIFF
--- a/pages/profile/invitations/index.js
+++ b/pages/profile/invitations/index.js
@@ -8,6 +8,16 @@ module.exports = settings => {
     root: __dirname
   });
 
+  app.use((req, res, next) => {
+    req.datatable = {
+      sort: {
+        column: 'createdAt',
+        ascending: false
+      }
+    };
+    next();
+  });
+
   app.use(datatable({
     getApiPath: (req, res, next) => {
       req.datatable.apiPath = `/establishment/${req.establishmentId}/invitations`;

--- a/pages/profile/invite/index.js
+++ b/pages/profile/invite/index.js
@@ -38,7 +38,7 @@ module.exports = settings => {
       }
     }]);
     delete req.session.form[id];
-    return res.redirect(req.originalUrl.replace(/\/invite/, ''));
+    return res.redirect(`${req.buildRoute('profile.list')}/invitations`);
   });
 
   return app;


### PR DESCRIPTION
Redirect to the list of open invitations after inviting a new user. Sort the table by `createdAt` with newest to the top so that the new invitation is visible at the top of the list.