### PR TITLE
Hide edit controls for non-admin users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-2.1.1.tgz",
-      "integrity": "sha1-ZgTg4CJetYqc8jk4v4j1P6PL2Hg=",
+      "version": "2.2.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-2.2.0.tgz",
+      "integrity": "sha1-NWDqzxSqmxQBov5H1WF8N+fOvMw=",
       "requires": {
         "@asl/dictionary": "^1.1.1",
         "@ukhomeoffice/react-components": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^2.1.1",
+    "@asl/components": "^2.2.0",
     "@asl/constants": "^0.3.1",
     "@asl/dictionary": "^1.1.1",
     "@asl/service": "^6.10.0",

--- a/pages/place/list/views/index.jsx
+++ b/pages/place/list/views/index.jsx
@@ -1,16 +1,15 @@
 import React, { Fragment } from 'react';
 import get from 'lodash/get';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
-import ReactMarkdown from 'react-markdown';
 import {
   FilterTable,
   Snippet,
-  Controls,
   Link,
   Header
 } from '@asl/components';
 import formatters from '../../formatters';
+
+import ExpandableRow from './row';
 
 const pageFormatters = {
   name: {
@@ -32,42 +31,30 @@ const pageFormatters = {
   }
 };
 
-const ExpandableRow = ({ row, schema }) => (
-  <div className="govuk-grid-row">
-    <div className={classnames({
-      'govuk-grid-column-one-quarter': row.restrictions,
-      'govuk-grid-column-full': !row.restrictions
-    })}>
-      <Controls item={row.id} />
-    </div>
-    {
-      row.restrictions && (
-        <div className="govuk-grid-column-two-thirds">
-          <h3>{<Snippet>fields.changesToRestrictions.label</Snippet>}</h3>
-          <ReactMarkdown>{row.restrictions}</ReactMarkdown>
-        </div>
-      )
-    }
-  </div>
-);
-
 const Places = ({
   establishment: { name },
   allowedActions,
   ...props
-}) => (
-  <Fragment>
+}) => {
+  const expands = row => {
+    if (!allowedActions.includes('place.update') && !row.restrictions) {
+      return null;
+    }
+    return <ExpandableRow row={row} />;
+  };
+
+  return <Fragment>
     <Header
       title={<Snippet>pages.place.list</Snippet>}
       subtitle={name}
     />
     <FilterTable
       formatters={Object.assign({}, formatters, pageFormatters)}
-      ExpandableRow={ExpandableRow}
+      expands={expands}
       createPath={allowedActions.includes('place.create') && 'place.create.new'}
     />
-  </Fragment>
-);
+  </Fragment>;
+};
 
 const mapStateToProps = ({ static: { establishment, allowedActions } }) => ({ establishment, allowedActions });
 

--- a/pages/place/list/views/row.jsx
+++ b/pages/place/list/views/row.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+import ReactMarkdown from 'react-markdown';
+import {
+  Snippet,
+  Controls
+} from '@asl/components';
+
+const ExpandableRow = ({ row, schema, allowedActions }) => {
+  if (!allowedActions.includes('place.update') && !row.restrictions) {
+    return null;
+  }
+  return <div className="govuk-grid-row">
+    <div className={classnames({
+      'govuk-grid-column-one-quarter': row.restrictions,
+      'govuk-grid-column-full': !row.restrictions
+    })}>
+      {
+        allowedActions.includes('place.update') && <Controls item={row.id} />
+      }
+    </div>
+    {
+      row.restrictions && (
+        <div className="govuk-grid-column-two-thirds">
+          <h3>{<Snippet>fields.changesToRestrictions.label</Snippet>}</h3>
+          <ReactMarkdown>{row.restrictions}</ReactMarkdown>
+        </div>
+      )
+    }
+  </div>;
+};
+
+const mapStateToProps = ({ static: { allowedActions } }) => ({ allowedActions });
+
+export default connect(mapStateToProps)(ExpandableRow);

--- a/pages/place/list/views/row.jsx
+++ b/pages/place/list/views/row.jsx
@@ -8,9 +8,6 @@ import {
 } from '@asl/components';
 
 const ExpandableRow = ({ row, schema, allowedActions }) => {
-  if (!allowedActions.includes('place.update') && !row.restrictions) {
-    return null;
-  }
   return <div className="govuk-grid-row">
     <div className={classnames({
       'govuk-grid-column-one-quarter': row.restrictions,


### PR DESCRIPTION
Apply a filter on `place.update` permissions when showing the edit controls on a row of the schedule of premises.