### PR TITLE
Prevent mutating common content when extending

### DIFF
--- a/pages/pil/read/content/index.js
+++ b/pages/pil/read/content/index.js
@@ -1,7 +1,7 @@
 const { merge } = require('lodash');
 const baseContent = require('../../content');
 
-module.exports = merge(baseContent, {
+module.exports = merge({}, baseContent, {
   status: {
     inactive: 'You do not currently hold a Personal Licence, [click here]({{url}}) to apply for one'
   }

--- a/pages/profile/roles/content/confirm.js
+++ b/pages/profile/roles/content/confirm.js
@@ -1,7 +1,7 @@
 const { merge } = require('lodash');
 const baseContent = require('../../content');
 
-module.exports = merge(baseContent, {
+module.exports = merge({}, baseContent, {
   reviewRoleApplication: 'Please review your application for a named role',
   applyingFor: 'You are applying for the role:',
   onBehalfOf: 'On behalf of:',

--- a/pages/profile/roles/content/index.js
+++ b/pages/profile/roles/content/index.js
@@ -1,7 +1,7 @@
 const { merge } = require('lodash');
 const baseContent = require('../../content');
 
-module.exports = merge(baseContent, {
+module.exports = merge({}, baseContent, {
   title: 'Which role do you want to apply for?',
   fields: {
     role: {

--- a/pages/profile/roles/content/success.js
+++ b/pages/profile/roles/content/success.js
@@ -1,7 +1,7 @@
 const { merge } = require('lodash');
 const baseContent = require('../../content');
 
-module.exports = merge(baseContent, {
+module.exports = merge({}, baseContent, {
   panel: {
     title: 'Application submitted to ASRU',
     summary: 'A confirmation email has been sent to'


### PR DESCRIPTION
`merge` will mutate the object provided as the first argument, so passing a common content object as the first argument causes the common content to be overwritten with the custom content, and can lead to incorrect content being displayed in other situations.

Instead pass an empty object as a first argument to create a new content object.