### PR TITLE
Improve content in task list pages

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -4,6 +4,15 @@ module.exports = {
   fields,
   title: 'Task List',
   task: {
+    role: {
+      create: 'Add named person',
+      delete: 'Remove named person'
+    },
+    place: {
+      create: 'Add licensed premises',
+      update: 'Amend licensed premises',
+      delete: 'Remove licensed premises'
+    },
     pil: {
       grant: 'PIL Application'
     }

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -13,7 +13,18 @@ const formatters = {
     format: date => format(date, dateFormat.medium)
   },
   licence: {
-    format: licence => licence ? licence.toUpperCase() : null
+    format: licence => {
+      if (licence === 'pil') {
+        return 'PIL';
+      }
+      if (licence === 'project') {
+        return 'PPL';
+      }
+      if (licence === 'place' || licence === 'role' || licence === 'establishment') {
+        return 'PEL';
+      }
+      return null;
+    }
   },
   type: {
     format: (type, model) => {


### PR DESCRIPTION
Model types don't map one-to-one to licence types, most are PEL.

Add more action types to content file. This is not complete, more are coming, but I think it covers everything that's possible in system today.