### PR TITLE
Display a different error message if the NTCO does not have profile read perms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       "integrity": "sha1-oaK4axlNOaArI0+RblmPPwsMeG0="
     },
     "@asl/service": {
-      "version": "6.15.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-6.15.0.tgz",
-      "integrity": "sha1-X+AU5XqoMVR40PnbFq36SSJI8ls=",
+      "version": "6.17.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-6.17.0.tgz",
+      "integrity": "sha1-1qOUmJrt6BBgifTTEygHPnyiorg=",
       "requires": {
         "@asl/components": "^2.3.2",
         "@lennym/redis-session": "^1.0.4",
@@ -142,11 +142,11 @@
           }
         },
         "react-markdown": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.4.tgz",
-          "integrity": "sha512-G2dpkraP12A/1xZ1oJgm0hop213kscc7jMY0hqlx9VgxJ+5Jda1C+E+HVFL8PL0WGMVxgh95ksQzFXYGBcnQ9g==",
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.6.tgz",
+          "integrity": "sha512-E1d/q+OBk5eumId42oYqVrJRB/+whrZdk+YHqUBCCNeWxqeV+Qzt+yLTsft9+4HRDj89Od7eAbUPQBYq8ZwShQ==",
           "requires": {
-            "html-to-react": "^1.3.3",
+            "html-to-react": "^1.3.4",
             "mdast-add-list-metadata": "1.0.1",
             "prop-types": "^15.6.1",
             "remark-parse": "^5.0.0",
@@ -1084,11 +1084,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "arity-n": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
-    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -1258,7 +1253,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -2880,11 +2875,6 @@
         "parse5": "^3.0.1"
       }
     },
-    "chickencurry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chickencurry/-/chickencurry-1.1.1.tgz",
-      "integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg="
-    },
     "chokidar": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
@@ -3315,14 +3305,6 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
-    "compose-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-2.0.0.tgz",
-      "integrity": "sha1-5kL6fh2iFSlyADFHZ3b8JGkawLA=",
-      "requires": {
-        "arity-n": "^1.0.4"
-      }
-    },
     "compress-commons": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
@@ -3423,9 +3405,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -7167,15 +7149,15 @@
       }
     },
     "html-to-react": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.3.tgz",
-      "integrity": "sha512-4Qi5/t8oBr6c1t1kBJKyxEeJu0lb7ctvq29oFZioiUHH0Wz88VWGwoXuH26HDt9v64bDHA4NMPNTH8bVrcaJWA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
+      "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
       "requires": {
-        "domhandler": "^2.3.0",
+        "domhandler": "^2.4.2",
         "escape-string-regexp": "^1.0.5",
-        "htmlparser2": "^3.8.3",
-        "ramda": "^0.25.0",
-        "underscore.string.fp": "^1.0.4"
+        "htmlparser2": "^3.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
       }
     },
     "htmlparser2": {
@@ -8684,12 +8666,13 @@
       "dev": true
     },
     "js-beautify": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.8.tgz",
-      "integrity": "sha512-qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.9.tgz",
+      "integrity": "sha512-MwPmLywK9RSX0SPsUJjN7i+RQY9w/yC17Lbrq9ViEefpLRgqAR2BgrMN2AbifkUuhDV8tRauLhLda/9+bE0YQA==",
       "requires": {
-        "config-chain": "~1.1.5",
-        "editorconfig": "^0.15.0",
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.2",
+        "glob": "^7.1.3",
         "mkdirp": "~0.5.0",
         "nopt": "~4.0.1"
       }
@@ -8933,9 +8916,9 @@
       "dev": true
     },
     "jwk-to-pem": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.0.tgz",
-      "integrity": "sha512-7cdRdbs6anizNwmUgFKcgF2isuf6ErE95R5B1hA2RS0F2jxPoTmR+QUK4Syc92LWdgGZ1JnUDM3qssNENAoaAg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.1.tgz",
+      "integrity": "sha512-KKu0WuDDjqw2FlRFp9/vk9TMO/KvgpZVKzdhhYcNyy5OwE8dw9lOK5OQTQHIJ7m+HioI/4P44sAtVuDrQ8KQfw==",
       "requires": {
         "asn1.js": "^4.5.2",
         "elliptic": "^6.2.3",
@@ -8943,9 +8926,9 @@
       }
     },
     "keycloak-connect": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-4.7.0.tgz",
-      "integrity": "sha512-cZ9uuOLQgfJxZZVhWT8vNmatcVNUc1hcLQzXV3iFwR5SoT0ekFvcJV4TFkGtbooCta6amVATuHDdPvNFuk9Lzg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-4.8.3.tgz",
+      "integrity": "sha512-4MRRDmztHl2c1JiyxoZO3aAkqeYQ06gKUXJQ5BjL1RGZuqDs2I8vmSUL+ou4Gm0NamoJa87daT1NBg98ZW1mhw==",
       "requires": {
         "jwk-to-pem": "^2.0.0"
       }
@@ -11282,9 +11265,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randexp": {
       "version": "0.4.6",
@@ -12220,11 +12203,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "reverse-arguments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
-      "integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80="
     },
     "rgb2hex": {
       "version": "0.1.9",
@@ -14503,22 +14481,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
-    },
-    "underscore.string": {
-      "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-      "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
-    },
-    "underscore.string.fp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/underscore.string.fp/-/underscore.string.fp-1.0.4.tgz",
-      "integrity": "sha1-BUs/GEO8rlYShsh95eiHm0/Jg2Q=",
-      "requires": {
-        "chickencurry": "1.1.1",
-        "compose-function": "^2.0.0",
-        "reverse-arguments": "1.0.0",
-        "underscore.string": "3.0.3"
-      }
     },
     "unherit": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@asl/components": "^3.5.0",
     "@asl/constants": "^0.3.1",
     "@asl/dictionary": "^1.1.1",
-    "@asl/service": "^6.15.0",
+    "@asl/service": "^6.17.0",
     "@ukhomeoffice/frontend-toolkit": "^2.5.0",
     "@ukhomeoffice/react-components": "^0.5.1",
     "babel-core": "^6.26.3",

--- a/pages/task/read/content/pil.js
+++ b/pages/task/read/content/pil.js
@@ -43,7 +43,7 @@ module.exports = {
     }
   },
   errors: {
-    permissions: `You do not currently have permission to view all profiles at this establishment. Please contact your
-      establishment admin to increase your permissions level.`
+    permissions: `You do not currently have permission to view all people at this establishment. Please contact an
+    establishment administrator to increase your permissions level.`
   }
 };

--- a/pages/task/read/content/pil.js
+++ b/pages/task/read/content/pil.js
@@ -41,5 +41,9 @@ module.exports = {
       title: 'Procedure categories',
       categories: 'Categories'
     }
+  },
+  errors: {
+    permissions: `You do not currently have permission to view all profiles at this establishment. Please contact your
+      establishment admin to increase your permissions level.`
   }
 };

--- a/pages/task/read/index.js
+++ b/pages/task/read/index.js
@@ -22,22 +22,24 @@ module.exports = settings => {
   });
 
   app.use('/', (req, res, next) => {
-    Promise.resolve()
-      .then(() => req.user.can('profile.read.all', { establishment: req.task.data.data.establishmentId }))
-      .then(canReadAllProfiles => {
-        if (!canReadAllProfiles) {
-          const content = getContent(req.task);
-          next(new UnauthorisedError(content.errors.permissions));
-        }
-      });
-
     if (req.task.data.data.profileId && req.task.data.data.establishmentId) {
       return req.api(`/establishment/${req.task.data.data.establishmentId}/profile/${req.task.data.data.profileId}`)
         .then(({ json: { data } }) => {
           req.profile = cleanModel(data);
         })
         .then(() => next())
-        .catch(next);
+        .catch(error => {
+          return Promise.resolve()
+            .then(() => req.user.can('profile.read.all', { establishment: req.task.data.data.establishmentId }))
+            .then(canReadAllProfiles => {
+              if (!canReadAllProfiles) {
+                const content = getContent(req.task);
+                next(new UnauthorisedError(content.errors.permissions));
+              } else {
+                next(error);
+              }
+            });
+        });
     }
     next();
   });


### PR DESCRIPTION
If the NTCO cannot view all profiles at an establishment then they will not be able to endorse PILs for non-named users.

We should make this obvious using a different error message.