### PR TITLE
Fix the place update confirm page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "3.5.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-3.5.0.tgz",
-      "integrity": "sha1-dctrmcVJWdVi5npZEQEZQ0c6vJU=",
+      "version": "3.5.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-3.5.1.tgz",
+      "integrity": "sha1-DhzSpte6DqBQnCebepR+IFhme7c=",
       "requires": {
         "@asl/dictionary": "^1.1.1",
         "@ukhomeoffice/react-components": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^3.5.0",
+    "@asl/components": "^3.5.1",
     "@asl/constants": "^0.3.1",
     "@asl/dictionary": "^1.1.1",
     "@asl/service": "^6.15.0",

--- a/pages/place/schema/declarations.js
+++ b/pages/place/schema/declarations.js
@@ -21,6 +21,7 @@ module.exports = {
       customValidate: (field, model) => {
         return isEqual(optionValues, model.declarations);
       }
-    }]
+    }],
+    showDiff: false
   }
 };


### PR DESCRIPTION
The update confirm was breaking because the diff component was attempting to render the declaration field that's now in the schema.

A flag has been added that lets you disable a field from displaying in the diff.