### PR TITLE
Refactor task display to decouple from PIL endorsement

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -84,6 +84,12 @@ const licenceCanProgress = decision => {
   ].includes(decision);
 };
 
+const requiresDeclaration = decision => {
+  return [
+    'ntco-endorsed'
+  ].includes(decision);
+};
+
 module.exports = {
   toTitleCase,
   getTitle,
@@ -94,5 +100,6 @@ module.exports = {
   removeQueryParams,
   toArray,
   buildModel,
-  licenceCanProgress
+  licenceCanProgress,
+  requiresDeclaration
 };

--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -5,7 +5,7 @@ module.exports = {
       label: 'What is your decision?'
     },
     reason: {
-      label: 'Reason for decision'
+      label: 'Comment'
     },
     options: {
       'ntco-endorsed': {

--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -1,4 +1,42 @@
 module.exports = {
+  title: 'Review Application',
+  fields: {
+    decision: {
+      label: 'What is your decision?'
+    },
+    reason: {
+      label: 'Reason for decision'
+    },
+    options: {
+      'ntco-endorsed': {
+        label: 'Endorse application'
+      },
+      'resubmitted': {
+        label: 'Resubmit'
+      },
+      'returned-to-applicant': {
+        label: 'Return to applicant'
+      },
+      'withdrawn-by-applicant': {
+        label: 'Withdraw'
+      },
+      'referred-to-inspector': {
+        label: 'Refer to inspector'
+      },
+      'inspector-recommended': {
+        label: 'Recommend'
+      },
+      'inspector-rejected': {
+        label: 'Recommend for rejection'
+      },
+      'resolved': {
+        label: 'Grant licence'
+      },
+      'rejected': {
+        label: 'Reject'
+      }
+    }
+  },
   task: {
     submittedBy: 'Submitted by',
     submittedOn: 'on {{date}}.',

--- a/pages/task/read/content/confirm.js
+++ b/pages/task/read/content/confirm.js
@@ -21,6 +21,27 @@ module.exports = {
            * I have the authority of the establishment licence holder, and they are aware that this establishment will
            have financial responsibility for this personal licence if granted.`
     },
+    'resubmitted': {
+      decision: 'Resubmitted'
+    },
+    'withdrawn-by-applicant': {
+      decision: 'Withdrawn'
+    },
+    'referred-to-inspector': {
+      decision: 'Referred to inspector'
+    },
+    'inspector-recommended': {
+      decision: 'Recommended'
+    },
+    'inspector-rejected': {
+      decision: 'Recommended for rejection'
+    },
+    'resolved': {
+      decision: 'Licence updated'
+    },
+    'rejected': {
+      decision: 'Rejected'
+    },
     'returned-to-applicant': {
       decision: 'Returned to applicant'
     }

--- a/pages/task/read/content/pil.js
+++ b/pages/task/read/content/pil.js
@@ -7,17 +7,15 @@ module.exports = {
     reason: {
       label: 'Reason for rejection'
     },
-    options: [
-      {
+    options: {
+      'ntco-endorsed': {
         label: 'Yes',
-        hint: 'I confirm that the applicant holds the neccessary training or experience to carry out the categories of procedures listed in this application',
-        value: 'ntco-endorsed'
+        hint: 'I confirm that the applicant holds the neccessary training or experience to carry out the categories of procedures listed in this application'
       },
-      {
-        label: 'No',
-        value: 'returned-to-applicant'
+      'returned-to-applicant': {
+        label: 'No'
       }
-    ]
+    }
   },
   pil: {
     training: {

--- a/pages/task/read/content/success.js
+++ b/pages/task/read/content/success.js
@@ -15,8 +15,29 @@ module.exports = {
         they need more information.`
     },
     'returned-to-applicant': {
-      title: 'Application not endorsed',
+      title: 'Returned to applicant',
       summary: 'The applicant has been notified about your decision'
+    },
+    'resubmitted': {
+      title: 'Resubmitted'
+    },
+    'withdrawn-by-applicant': {
+      title: 'Withdrawn'
+    },
+    'referred-to-inspector': {
+      title: 'Referred to inspector'
+    },
+    'inspector-recommended': {
+      title: 'Recommended'
+    },
+    'inspector-rejected': {
+      title: 'Recommended for rejection'
+    },
+    'resolved': {
+      title: 'Licence updated'
+    },
+    'rejected': {
+      title: 'Rejected'
     }
   },
   states: {

--- a/pages/task/read/index.js
+++ b/pages/task/read/index.js
@@ -5,7 +5,7 @@ const confirm = require('./routers/confirm');
 const { cleanModel } = require('../../../lib/utils');
 const success = require('./routers/success');
 const getContent = require('./content');
-const { merge, get } = require('lodash');
+const { merge } = require('lodash');
 const UnauthorisedError = require('@asl/service/errors/unauthorised');
 
 module.exports = settings => {
@@ -46,7 +46,7 @@ module.exports = settings => {
 
   app.use('/', form(Object.assign({
     configure: (req, res, next) => {
-      const content = merge(res.locals.static.content, getContent(req.task));
+      merge(res.locals.static.content, getContent(req.task));
       req.schema = schemaGenerator(req.task);
       req.form.schema = req.schema;
 

--- a/pages/task/read/index.js
+++ b/pages/task/read/index.js
@@ -48,56 +48,7 @@ module.exports = settings => {
     configure: (req, res, next) => {
       const content = merge(res.locals.static.content, getContent(req.task));
       req.schema = schemaGenerator(req.task);
-
-      // create error messages for the dynamic textareas
-      Object.assign({},
-        res.locals.static.content.errors,
-        {
-          ...req.task.nextSteps.reduce((obj, step) => {
-            if (!step.commentRequired) {
-              return obj;
-            }
-            return {
-              ...obj,
-              [`${step.id}-reason`]: {
-                customValidate: get(content, 'errors.reason.customValidate')
-              }
-            };
-          }, {})
-        }
-      );
-      // create field labels for the dynamic textareas
-      Object.assign({},
-        res.locals.static.content.fields,
-        {
-          ...req.task.nextSteps.reduce((obj, step) => {
-            if (!step.commentRequired) {
-              return obj;
-            }
-            return {
-              ...obj,
-              [`${step.id}-reason`]: {
-                label: get(content, 'fields.reason.label')
-              }
-            };
-          }, {})
-        }
-      );
-
-      // copy the reason fields to the top level for validation / saving
-      req.form.schema = {
-        ...req.schema,
-        ...req.schema.decision.options.reduce((obj, option) => {
-          if (!option.reveal || !option.reveal[`${option.value}-reason`]) {
-            return obj;
-          }
-
-          return {
-            ...obj,
-            [`${option.value}-reason`]: option.reveal[`${option.value}-reason`]
-          };
-        }, {})
-      };
+      req.form.schema = req.schema;
 
       next();
     },

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -13,28 +13,21 @@ module.exports = () => {
   app.use(form({
     locals: (req, res, next) => {
       const formValues = req.session.form[`${req.task.id}-decision`].values;
-      console.log(formValues);
-      const decision = formValues.decision;
 
       res.locals.static.task = req.task;
-      res.locals.static.decision = decision;
+      res.locals.static.decision = formValues.decision;
       res.locals.static.reason = formValues.reason;
       next();
     }
   }));
 
   app.post('/', (req, res, next) => {
-    const commentRequired = stepId => {
-      return req.task.nextSteps.find(nextStep => nextStep.id === stepId).commentRequired;
-    };
-
     const formValues = req.session.form[`${req.task.id}-decision`].values;
-    const stepId = formValues.decision;
-    const params = { status: stepId };
 
-    if (commentRequired(stepId)) {
-      params.comment = formValues.reason;
-    }
+    const params = {
+      status: formValues.decision,
+      comment: formValues.reason
+    };
 
     const opts = {
       method: 'PUT',

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -13,11 +13,12 @@ module.exports = () => {
   app.use(form({
     locals: (req, res, next) => {
       const formValues = req.session.form[`${req.task.id}-decision`].values;
+      console.log(formValues);
       const decision = formValues.decision;
 
       res.locals.static.task = req.task;
       res.locals.static.decision = decision;
-      res.locals.static.reason = formValues[`${decision}-reason`];
+      res.locals.static.reason = formValues.reason;
       next();
     }
   }));
@@ -32,7 +33,7 @@ module.exports = () => {
     const params = { status: stepId };
 
     if (commentRequired(stepId)) {
-      params.comment = formValues[`${stepId}-reason`];
+      params.comment = formValues.reason;
     }
 
     const opts = {

--- a/pages/task/read/views/confirm.jsx
+++ b/pages/task/read/views/confirm.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { FormLayout, Link, Snippet, Header } from '@asl/components';
-import { licenceCanProgress } from '../../../../lib/utils';
+import { requiresDeclaration } from '../../../../lib/utils';
 
 const Confirm = ({ task, decision, reason }) => {
   return (
@@ -18,7 +18,7 @@ const Confirm = ({ task, decision, reason }) => {
           { reason && <p>{reason}</p> }
         </div>
 
-        { licenceCanProgress(decision) &&
+        { requiresDeclaration(decision) &&
           <div className="task-declaration">
             <h2><Snippet>task.confirm.declaration.title</Snippet></h2>
             <Snippet>{`task.${decision}.declaration`}</Snippet>

--- a/pages/task/read/views/index.jsx
+++ b/pages/task/read/views/index.jsx
@@ -9,7 +9,7 @@ import {
   Snippet,
   Header
 } from '@asl/components';
-import Pil from './pil';
+import Playback from './playback';
 import { dateFormat } from '../../../../constants';
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
@@ -64,26 +64,22 @@ const Task = ({ task }) => {
         <Link page="profile.view" profileId={changedBy.id} label={changedBy.name} /><span>&nbsp;</span>
         <Snippet date={formatDate(parse(task.updatedAt))}>task.submittedOn</Snippet>
       </div>
+      {
+        subject && <div className="applicant">
+          <h2 className="govuk-heading-m"><Snippet>task.applicantName</Snippet></h2>
+          <p className="govuk-body">{subject.name}</p>
+        </div>
+      }
 
-      <div className="applicant">
-        <h2 className="govuk-heading-m"><Snippet>task.applicantName</Snippet></h2>
-        <p className="govuk-body">{subject.name}</p>
-      </div>
+      <Playback task={task} />
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-third">
-          <ol className="section-navigation">
-            <li className="active"><a href="#training">Training and exemptions</a></li>
-            <li><a href="#procedures">Procedure Categories</a></li>
-            <li><a href="#endorse">Endorse Application</a></li>
-          </ol>
+          &nbsp;
         </div>
 
         <div className="govuk-grid-column-two-thirds">
-          <Pil />
-          <div id="endorse">
-            <Form formatters={formatters} />
-          </div>
+          <Form formatters={formatters} />
         </div>
       </div>
 

--- a/pages/task/read/views/pil.jsx
+++ b/pages/task/read/views/pil.jsx
@@ -9,61 +9,71 @@ const Pil = ({ profile }) => {
   const pil = profile.pil;
   const formatDate = date => format(date, dateFormat.short);
   return (
-    <Fragment>
-      <h2><Snippet>pil.training.title</Snippet></h2>
-      { profile.certificates.length && profile.certificates.map((certificate, index) => (
-        <div key={index}>
-          <Fragment>
-            <h3><Snippet>pil.training.certificate.details</Snippet></h3>
-            <p><Snippet>pil.training.certificate.number</Snippet><span>:</span> {certificate.certificateNumber}</p>
-            <p><Snippet>pil.training.certificate.awarded</Snippet><span>:</span> {formatDate(certificate.passDate)}</p>
-            <p><Snippet>pil.training.certificate.expiry</Snippet><span>:</span> {formatDate(addYears(certificate.passDate, 5))}</p>
-            <p><Snippet>pil.training.certificate.body</Snippet><span>:</span> {certificate.accreditingBody}</p>
-            <p></p><Snippet>pil.training.certificate.file</Snippet><span>:</span> <br/>
-          </Fragment>
-          <br />
-          <Fragment>
-            <h3><Snippet>pil.training.modules</Snippet></h3>
-            <ul>
-              { certificate.modules.map((module, index) => (
-                <li key={index}>{module.module}</li>
-              )) }
-            </ul>
-          </Fragment>
-          <br />
-        </div>
-      )) }
-      <hr /><br />
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-third">
+        <ol className="section-navigation">
+          <li className="active"><a href="#training">Training and exemptions</a></li>
+          <li><a href="#procedures">Procedure Categories</a></li>
+          <li><a href="#endorse">Endorse Application</a></li>
+        </ol>
+      </div>
 
-      <div id="exemptions">
-        <h2><Snippet>pil.exemptions.title</Snippet></h2>
-        { profile.exemptions.length && profile.exemptions.map((exemption, index) => (
+      <div className="govuk-grid-column-two-thirds">
+        <h2><Snippet>pil.training.title</Snippet></h2>
+        { profile.certificates.length && profile.certificates.map((certificate, index) => (
           <div key={index}>
-            <dl>
-              <dt><Snippet>pil.exemptions.module</Snippet><span>:</span></dt>
-              <dd>{exemption.module}</dd>
-
-              <dt><Snippet>pil.exemptions.reason</Snippet><span>:</span></dt>
-              <dd>{exemption.description}</dd>
-            </dl>
+            <Fragment>
+              <h3><Snippet>pil.training.certificate.details</Snippet></h3>
+              <p><Snippet>pil.training.certificate.number</Snippet><span>:</span> {certificate.certificateNumber}</p>
+              <p><Snippet>pil.training.certificate.awarded</Snippet><span>:</span> {formatDate(certificate.passDate)}</p>
+              <p><Snippet>pil.training.certificate.expiry</Snippet><span>:</span> {formatDate(addYears(certificate.passDate, 5))}</p>
+              <p><Snippet>pil.training.certificate.body</Snippet><span>:</span> {certificate.accreditingBody}</p>
+              <p></p><Snippet>pil.training.certificate.file</Snippet><span>:</span> <br/>
+            </Fragment>
+            <br />
+            <Fragment>
+              <h3><Snippet>pil.training.modules</Snippet></h3>
+              <ul>
+                { certificate.modules.map((module, index) => (
+                  <li key={index}>{module.module}</li>
+                )) }
+              </ul>
+            </Fragment>
+            <br />
           </div>
-        ))}
+        )) }
         <hr /><br />
-      </div>
 
-      <div id="procedures">
-        <h2><Snippet>pil.procedures.title</Snippet></h2>
-        <h3><Snippet>pil.procedures.categories</Snippet></h3>
-        { pil.procedures.length && (
-          <Fragment>
-            { pil.procedures.map((procedure, index) => (
-              <p key={index}>{`${procedure.toUpperCase()}. ${procedureDefinitions[procedure]}`}</p>
-            ))}
-          </Fragment>
-        ) }
-        <hr />
+        <div id="exemptions">
+          <h2><Snippet>pil.exemptions.title</Snippet></h2>
+          { profile.exemptions.length && profile.exemptions.map((exemption, index) => (
+            <div key={index}>
+              <dl>
+                <dt><Snippet>pil.exemptions.module</Snippet><span>:</span></dt>
+                <dd>{exemption.module}</dd>
+
+                <dt><Snippet>pil.exemptions.reason</Snippet><span>:</span></dt>
+                <dd>{exemption.description}</dd>
+              </dl>
+            </div>
+          ))}
+          <hr /><br />
+        </div>
+
+        <div id="procedures">
+          <h2><Snippet>pil.procedures.title</Snippet></h2>
+          <h3><Snippet>pil.procedures.categories</Snippet></h3>
+          { pil.procedures.length && (
+            <Fragment>
+              { pil.procedures.map((procedure, index) => (
+                <p key={index}>{`${procedure.toUpperCase()}. ${procedureDefinitions[procedure]}`}</p>
+              ))}
+            </Fragment>
+          ) }
+          <hr />
+        </div>
       </div>
-    </Fragment>
+    </div>
   );
 };
 

--- a/pages/task/read/views/playback.jsx
+++ b/pages/task/read/views/playback.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Pil from './pil';
+
+export default task => {
+
+  if (task.model === 'pil') {
+    return <Pil />;
+  }
+
+  return null;
+
+};

--- a/pages/task/read/views/success.jsx
+++ b/pages/task/read/views/success.jsx
@@ -14,7 +14,7 @@ const Success = ({ decision }) => (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
         <Panel title={<Snippet>{`task.${decision}.title`}</Snippet>} className="green-bg">
-          <Snippet>{`task.${decision}.summary`}</Snippet>
+          <Snippet optional>{`task.${decision}.summary`}</Snippet>
 
           { licenceCanProgress(decision) &&
             <ApplicationProgress states={STATES} />
@@ -24,11 +24,11 @@ const Success = ({ decision }) => (
         { licenceCanProgress(decision) &&
           <Fragment>
             <div className="what-next">
-              <h2><Snippet>{`task.${decision}.whatNext.title`}</Snippet></h2>
-              <p><Snippet>{`task.${decision}.whatNext.summary`}</Snippet></p>
+              <h2><Snippet optional>{`task.${decision}.whatNext.title`}</Snippet></h2>
+              <p><Snippet optional>{`task.${decision}.whatNext.summary`}</Snippet></p>
             </div>
 
-            <p><Snippet>{`task.${decision}.body`}</Snippet></p>
+            <p><Snippet optional>{`task.${decision}.body`}</Snippet></p>
           </Fragment>
         }
 

--- a/pages/task/schema/index.js
+++ b/pages/task/schema/index.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash');
 const getContent = require('../read/content');
 
 module.exports = (task) => {
@@ -8,23 +9,11 @@ module.exports = (task) => {
     return task.nextSteps.find(nextStep => nextStep.id === stepId).commentRequired;
   };
 
-  const reasonField = stepId => {
+  const options = task.nextSteps.map(option => {
     return {
-      [`${stepId}-reason`]: {
-        inputType: 'textarea',
-        validate: [{
-          customValidate: (field, model) => {
-            return (model.decision && commentRequired(model.decision)) ? !!field : true;
-          }
-        }]
-      }
-    };
-  };
-
-  const options = content.fields.options.map(option => {
-    return {
-      ...option,
-      reveal: task.nextSteps.find(step => step.id === option.value).commentRequired ? reasonField(option.value) : null
+      value: option.id,
+      label: get(content, `fields.options.${option.id}.label`),
+      hint: get(content, `fields.options.${option.id}.hint`)
     };
   });
 
@@ -39,6 +28,15 @@ module.exports = (task) => {
           definedValues: options.map(option => option.value)
         }
       ]
+    },
+    reason: {
+      inputType: 'textarea',
+      validate: [{
+        customValidate: (field, model) => {
+          return (model.decision && commentRequired(model.decision)) ? !!field : true;
+        }
+      }]
+
     }
   };
 


### PR DESCRIPTION
The content of the task modules was hard-coded to a lot of PIL content, which is not relevant to other tasks.

Refactor away the PIL specific content and provide fallbacks for a generic task.

Determine the available options from the output of the workflow API, and not locally defined content, with default content values provided for the available statuses.

Moves reason field out of a conditional reveal and allows a comment to be input for all decisions, only marking it mandatory for certain decisions.