### PR TITLE
Add status indicators to task lists

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -49,3 +49,19 @@
     }
   }
 }
+
+
+.badge {
+  padding: 3px 6px;
+  background: #999;
+  color: white;
+  text-transform: uppercase;
+  font-weight: bold;
+
+  &.complete {
+    background: $blue;
+  }
+  &.rejected {
+    background: $govuk-error-colour;
+  }
+}

--- a/pages/task/list/content/fields.js
+++ b/pages/task/list/content/fields.js
@@ -10,5 +10,8 @@ module.exports = {
   },
   type: {
     label: 'Type'
+  },
+  status: {
+    label: 'Status'
   }
 };

--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -21,5 +21,16 @@ module.exports = {
     pil: {
       grant: 'PIL Application'
     }
+  },
+  status: {
+    'returned-to-applicant': 'Returned to applicant',
+    'withdrawn-by-applicant': 'Withdrawn',
+    'with-ntco': 'Awaiting endorsement',
+    'with-licensing': 'Awaiting triage',
+    'referred-to-inspector': 'Awaiting inspection',
+    'inspector-recommended': 'Recommended',
+    'inspector-rejected': 'Not recommended',
+    resolved: 'Resolved',
+    rejected: 'Rejected'
   }
 };

--- a/pages/task/list/schema/index.js
+++ b/pages/task/list/schema/index.js
@@ -16,5 +16,9 @@ module.exports = {
     show: true,
     sortable: false,
     accessor: 'data.action'
+  },
+  status: {
+    show: true,
+    sortable: false
   }
 };

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import classnames from 'classnames';
 import get from 'lodash/get';
 import format from 'date-fns/format';
 import { dateFormat } from '../../../../constants';
@@ -8,6 +9,9 @@ import {
   Snippet,
   Link
 } from '@asl/components';
+
+const good = ['resolved'];
+const bad = ['rejected', 'withdrawn'];
 
 const formatters = {
   updatedAt: {
@@ -25,6 +29,12 @@ const formatters = {
         return 'PEL';
       }
       return null;
+    }
+  },
+  status: {
+    format: status => {
+      const className = classnames({ badge: true, complete: good.includes(status), rejected: bad.includes(status) });
+      return <span className={ className }><Snippet>{ `status.${status}` }</Snippet></span>;
     }
   },
   type: {


### PR DESCRIPTION
Adds an extra column to the tale that shows the current status of the change request. They show in grey for in progress tasks, and blue or red for closed tasks depending on state.