### PR TITLE
Add default tabs configuration to task list

### DIFF
--- a/pages/task/list/index.js
+++ b/pages/task/list/index.js
@@ -1,13 +1,13 @@
 const { page } = require('@asl/service/ui');
 const router = require('./router');
 
-module.exports = settings => {
+module.exports = (settings = {}) => {
   const app = page({
     ...settings,
     root: __dirname
   });
 
-  app.use(router());
+  app.use(router({ tabs: settings.tabs }));
 
   return app;
 };

--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -2,7 +2,11 @@ const { get } = require('lodash');
 const defaultSchema = require('./schema');
 const datatable = require('../../common/routers/datatable');
 
-module.exports = ({ apiPath = '/tasks', schema = defaultSchema } = {}) => datatable({
+module.exports = ({
+  apiPath = '/tasks',
+  schema = defaultSchema,
+  tabs = ['outstanding', 'inProgress', 'completed']
+} = {}) => datatable({
   getApiPath: (req, res, next) => {
     req.datatable.apiPath = [req.datatable.apiPath, { query: req.query }];
     next();
@@ -12,6 +16,7 @@ module.exports = ({ apiPath = '/tasks', schema = defaultSchema } = {}) => datata
     const lastName = get(req, 'user.profile.lastName');
     res.locals.static.profileName = `${firstName} ${lastName}`;
     res.locals.static.progress = req.query.progress;
+    res.locals.static.tabs = tabs;
     next();
   }
 })({ schema, apiPath });

--- a/pages/task/list/views/index.jsx
+++ b/pages/task/list/views/index.jsx
@@ -6,16 +6,16 @@ import {
   Snippet
 } from '@asl/components';
 
-const TaskListPage = ({ name }) => (
+const TaskListPage = ({ name, progress, tabs }) => (
   <Fragment>
     <Header
       title={<Snippet>title</Snippet>}
       subtitle={name}
     />
-    <TaskList />
+    <TaskList tabs={ tabs } progress={ progress } />
   </Fragment>
 );
 
-const mapStateToProps = ({ static: { profileName: name } }) => ({ name });
+const mapStateToProps = ({ static: { profileName: name, progress, tabs } }) => ({ name, progress, tabs });
 
 export default connect(mapStateToProps)(TaskListPage);


### PR DESCRIPTION
Allows tbs to be displayed in a task list implementation to be configurable from the page mount point.

Not used now, but eventually we will want a slightly different tab set for internal and external users which this will support.