### PR TITLE
Include progress param in datatable store

### DIFF
--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -16,6 +16,7 @@ module.exports = ({
     const lastName = get(req, 'user.profile.lastName');
     res.locals.static.profileName = `${firstName} ${lastName}`;
     res.locals.static.progress = req.query.progress;
+    res.locals.datatable.progress = req.query.progress;
     res.locals.static.tabs = tabs;
     next();
   }


### PR DESCRIPTION
This is required to expose the progress parameter to the xhr requests which load paginated data.