### PR TITLE
Remove declaration field in places summary

### DIFF
--- a/pages/place/create/content/index.js
+++ b/pages/place/create/content/index.js
@@ -12,5 +12,5 @@ module.exports = merge({}, commonContent, {
       label: 'Why are you making this addition?'
     }
   },
-  inset: 'Any addition to your licensed premises will need to be assesed'
+  inset: 'Any addition to your licensed premises will need to be assessed'
 });

--- a/pages/place/routers/confirm.js
+++ b/pages/place/routers/confirm.js
@@ -6,6 +6,10 @@ const declarationsSchema = require('../schema/declarations');
 module.exports = settings => form(Object.assign({
   model: 'place',
   schema: declarationsSchema,
+  saveValues: (req, res, next) => {
+    delete req.session.form[req.model.id].values.declarations;
+    next();
+  },
   locals: (req, res, next) => {
     Object.assign(res.locals, { model: req.model });
     Promise.all([


### PR DESCRIPTION
If you tick the declaration on the places confirm page, and then come back to it, it was attempting to render the declaration in the ModelSummary.