### PR TITLE
Allow modules with no species fix

### DIFF
--- a/pages/pil/training/routers/modules.js
+++ b/pages/pil/training/routers/modules.js
@@ -4,6 +4,13 @@ const { modules: schema } = require('../schema');
 const { pick, castArray } = require('lodash');
 const { buildModel } = require('../../../../lib/utils');
 
+const modulesThatRequireSpecies = [
+  'PILA (theory)',
+  'PILA (skills)',
+  'K (theory)',
+  'K (skills)'
+];
+
 module.exports = settings => {
   const app = Router();
 
@@ -27,6 +34,7 @@ module.exports = settings => {
     },
     locals: (req, res, next) => {
       res.locals.static.schema = schema;
+      res.locals.static.modulesThatRequireSpecies = modulesThatRequireSpecies;
       next();
     }
   }));
@@ -36,10 +44,15 @@ module.exports = settings => {
     const values = pick(req.session.form[req.model.id].values, fields);
 
     values.modules = values.modules.map(module => {
-      const species = req.form.values[`module-${module}-species`];
-      return { module,
-        species: castArray(species).filter(s => s !== '')
-      };
+      if (modulesThatRequireSpecies.includes(module)) {
+        const species = req.form.values[`module-${module}-species`];
+        return {
+          module,
+          species: castArray(species).filter(s => s !== '')
+        };
+      } else {
+        return { module };
+      }
     });
 
     const opts = {

--- a/pages/pil/training/routers/modules.js
+++ b/pages/pil/training/routers/modules.js
@@ -44,15 +44,17 @@ module.exports = settings => {
     const values = pick(req.session.form[req.model.id].values, fields);
 
     values.modules = values.modules.map(module => {
-      if (modulesThatRequireSpecies.includes(module)) {
-        const species = req.form.values[`module-${module}-species`];
-        return {
-          module,
-          species: castArray(species).filter(s => s !== '')
-        };
-      } else {
+      if (!modulesThatRequireSpecies.includes(module)) {
         return { module };
       }
+
+      const species = req.form.values[`module-${module}-species`];
+
+      if (!species) {
+        throw new Error(`Please select at least one type of animal for module ${module}`);
+      }
+
+      return { module, species: castArray(species).filter(s => s !== '') };
     });
 
     const opts = {

--- a/pages/pil/training/views/modules.jsx
+++ b/pages/pil/training/views/modules.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import {
   Snippet,
   FormLayout,
@@ -11,39 +12,34 @@ import { species } from '@asl/constants';
 const SPECIES_REVEAL_TOTAL_COUNT = 10;
 const SPECIES_REVEAL_VISIBLE_COUNT = 1;
 
-const REQUIRES_SPECIES = [
-  'PILA (theory)',
-  'PILA (skills)',
-  'K (theory)',
-  'K (skills)'
-];
-
-const formatters = {
-  modules: {
-    mapOptions: (op, b) => {
-      return {
-        ...op,
-        prefix: op.value,
-        reveal: REQUIRES_SPECIES.includes(op.value) ? (
-          <Inset>
-            <AddAnother label={<Snippet>fields.species.add</Snippet>}
-              totalCount={SPECIES_REVEAL_TOTAL_COUNT}
-              visibleCount= {SPECIES_REVEAL_VISIBLE_COUNT}>
-              <Select
-                name={`module-${op.value}-species`}
-                label={<Snippet>{`fields.species.label`}</Snippet>}
-                options={species}
-              />
-            </AddAnother>
-          </Inset>
-        ) : null
-      };
+const formatters = modulesThatRequireSpecies => {
+  return {
+    modules: {
+      mapOptions: (op, b) => {
+        return {
+          ...op,
+          prefix: op.value,
+          reveal: modulesThatRequireSpecies.includes(op.value) ? (
+            <Inset>
+              <AddAnother label={<Snippet>fields.species.add</Snippet>}
+                totalCount={SPECIES_REVEAL_TOTAL_COUNT}
+                visibleCount= {SPECIES_REVEAL_VISIBLE_COUNT}>
+                <Select
+                  name={`module-${op.value}-species`}
+                  label={<Snippet>{`fields.species.label`}</Snippet>}
+                  options={species}
+                />
+              </AddAnother>
+            </Inset>
+          ) : null
+        };
+      }
     }
-  }
+  };
 };
 
-const Page = () => (
-  <FormLayout formatters={formatters}>
+const Page = ({ modulesThatRequireSpecies }) => (
+  <FormLayout formatters={formatters(modulesThatRequireSpecies)}>
     <header>
       <h1>
         <Snippet>title</Snippet>
@@ -52,4 +48,6 @@ const Page = () => (
   </FormLayout>
 );
 
-export default Page;
+const mapStateToProps = ({ static: { modulesThatRequireSpecies } }) => ({ modulesThatRequireSpecies });
+
+export default connect(mapStateToProps)(Page);

--- a/pages/pil/update/views/index.jsx
+++ b/pages/pil/update/views/index.jsx
@@ -36,7 +36,7 @@ const Index = ({ establishment, certificates, exemptions, model, skipExemptions,
                 modules.map(({ module, species }, index) =>
                   <li key={index}>
                     { module }
-                    { species.length > 0 && <span className="species"> ({species.join(', ')})</span> }
+                    { species && species.length > 0 && <span className="species"> ({species.join(', ')})</span> }
                   </li>
                 )
               }


### PR DESCRIPTION
This does some early validation before submitting to the API for modules that require species.

https://github.com/UKHomeOffice/asl-schema/pull/134 should be merged, and then `asl-public-api` updated first.