### PR TITLE
Fix id properties in species selection

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -90,8 +90,13 @@ const requiresDeclaration = decision => {
   ].includes(decision);
 };
 
+const normalise = str => {
+  return str.toLowerCase().split(' ').join('-').replace(/[^a-z0-9]+/g, '');
+};
+
 module.exports = {
   toTitleCase,
+  normalise,
   getTitle,
   getValue,
   getSort,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "3.5.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-3.5.1.tgz",
-      "integrity": "sha1-DhzSpte6DqBQnCebepR+IFhme7c=",
+      "version": "3.5.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-3.5.2.tgz",
+      "integrity": "sha1-9qHa2R2GYDH/PH1VcBhalHCq8q0=",
       "requires": {
         "@asl/dictionary": "^1.1.1",
         "@ukhomeoffice/react-components": "^0.5.1",
@@ -24,27 +24,10 @@
         "url": "^0.11.0"
       },
       "dependencies": {
-        "html-to-react": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
-          "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
-          "requires": {
-            "domhandler": "^2.4.2",
-            "escape-string-regexp": "^1.0.5",
-            "htmlparser2": "^3.10.0",
-            "lodash.camelcase": "^4.3.0",
-            "ramda": "^0.26"
-          }
-        },
         "mustache": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
           "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
-        },
-        "ramda": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
         },
         "react-markdown": {
           "version": "4.0.6",
@@ -7101,6 +7084,18 @@
         "whatwg-encoding": "^1.0.1"
       }
     },
+    "html-to-react": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
+      "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
+      "requires": {
+        "domhandler": "^2.4.2",
+        "escape-string-regexp": "^1.0.5",
+        "htmlparser2": "^3.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      }
+    },
     "htmlparser2": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
@@ -11204,6 +11199,11 @@
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randexp": {
       "version": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^3.5.1",
+    "@asl/components": "^3.5.2",
     "@asl/constants": "^0.3.1",
     "@asl/dictionary": "^1.1.1",
     "@asl/service": "^6.17.2",

--- a/pages/pil/training/views/modules.jsx
+++ b/pages/pil/training/views/modules.jsx
@@ -9,13 +9,15 @@ import {
 import { Select } from '@ukhomeoffice/react-components';
 import { species } from '@asl/constants';
 
+import { normalise } from '../../../../lib/utils';
+
 const SPECIES_REVEAL_TOTAL_COUNT = 10;
 const SPECIES_REVEAL_VISIBLE_COUNT = 1;
 
 const formatters = modulesThatRequireSpecies => {
   return {
     modules: {
-      mapOptions: (op, b) => {
+      mapOptions: op => {
         return {
           ...op,
           prefix: op.value,
@@ -25,6 +27,7 @@ const formatters = modulesThatRequireSpecies => {
                 totalCount={SPECIES_REVEAL_TOTAL_COUNT}
                 visibleCount= {SPECIES_REVEAL_VISIBLE_COUNT}>
                 <Select
+                  id={`module-${normalise(op.value)}-species`}
                   name={`module-${op.value}-species`}
                   label={<Snippet>{`fields.species.label`}</Snippet>}
                   options={species}


### PR DESCRIPTION
The ids being passed to the species selector were previously non-unique and contained whitespace and other non-alphanumeric characters. This made the labels not correspond to the correct elements, and id selectors impossible to use in integration testing.