### PR TITLE
Add missing ntco-endorsed status

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -27,6 +27,7 @@ module.exports = {
     'returned-to-applicant': 'Returned to applicant',
     'withdrawn-by-applicant': 'Withdrawn',
     'with-ntco': 'Awaiting endorsement',
+    'ntco-endorsed': 'Awaiting review',
     'with-licensing': 'Awaiting review',
     'referred-to-inspector': 'Awaiting inspection',
     'inspector-recommended': 'Recommended',


### PR DESCRIPTION
This might not be needed depending on the outcome of https://jira.digital.homeoffice.gov.uk/browse/AS-962