### PR TITLE
Various bug fixes for Places restrictions

### DIFF
--- a/pages/place/content/fields.js
+++ b/pages/place/content/fields.js
@@ -17,7 +17,7 @@ module.exports = {
     label: 'Holding'
   },
   changesToRestrictions: {
-    label: 'Restrictions',
+    label: 'Changes to restrictions',
     conditionalReveal: {
       label: 'Do these restrictions need to be changed?',
       yesLabel: 'Yes',

--- a/pages/place/routers/amend.js
+++ b/pages/place/routers/amend.js
@@ -8,7 +8,16 @@ module.exports = settings => form(Object.assign({
   configure: (req, res, next) => {
     getSchemaWithNacwos(req, settings.schema || schema)
       .then(mappedSchema => {
-        req.model.changesToRestrictions = req.model.restrictions;
+        if (req.model.restrictions) {
+          // changesToRestrictions needs to be present in the model,
+          // otherwise no changes detected when only changing restrictions
+          req.model.changesToRestrictions = req.model.restrictions;
+        } else {
+          // only show changes field if we already have restrictions
+          delete mappedSchema.restrictions;
+          delete mappedSchema.changesToRestrictions;
+        }
+
         req.form.schema = mappedSchema;
       })
       .then(() => next())

--- a/pages/place/routers/amend.js
+++ b/pages/place/routers/amend.js
@@ -8,6 +8,7 @@ module.exports = settings => form(Object.assign({
   configure: (req, res, next) => {
     getSchemaWithNacwos(req, settings.schema || schema)
       .then(mappedSchema => {
+        req.model.changesToRestrictions = req.model.restrictions;
         req.form.schema = mappedSchema;
       })
       .then(() => next())

--- a/pages/place/update/views/confirm.jsx
+++ b/pages/place/update/views/confirm.jsx
@@ -63,10 +63,10 @@ const Confirm = ({
           )
         }
         {
-          values && values.restrictions && (
+          values && values.changesToRestrictions && (
             <Field
               title={<Snippet>fields.changesToRestrictions.label</Snippet>}
-              content={values.restrictions}
+              content={values.changesToRestrictions}
             />
           )
         }


### PR DESCRIPTION
This should now:
 * allow you to submit a change to a place's restrictions with no other changes
 * only display the current restrictions when removing a place (AS-854)
 * only display the "changes to restrictions" field when editing a place that already has restrictions

