### PR TITLE
Remove progress indicator from task success screen

### DIFF
--- a/pages/task/read/views/success.jsx
+++ b/pages/task/read/views/success.jsx
@@ -1,13 +1,7 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { ApplicationProgress, Link, Panel, Snippet } from '@asl/components';
+import { Link, Panel, Snippet } from '@asl/components';
 import { licenceCanProgress } from '../../../../lib/utils';
-
-const STATES = [
-  { state: 'submitted' },
-  { state: 'endorsed', active: true },
-  { state: 'granted' }
-];
 
 const Success = ({ status }) => (
   <Fragment>
@@ -15,10 +9,6 @@ const Success = ({ status }) => (
       <div className="govuk-grid-column-two-thirds">
         <Panel title={<Snippet>{`status.${status}.state`}</Snippet>} className="green-bg">
           <Snippet optional>{`status.${status}.summary`}</Snippet>
-
-          { licenceCanProgress(status) &&
-            <ApplicationProgress states={STATES} />
-          }
         </Panel>
 
         { licenceCanProgress(status) &&


### PR DESCRIPTION
This is currently flawed as it does not represent a full picture of the workflow, so can only be shown in certain circumstances (i.e. it makes no sense for an inspector as it doesn't show their actions) and is hard-coded to "Endorsed" so doesn't make sense for granting licences either.

Remove until a version that scales across all tasks and states is available.