### PR TITLE
Move p tag to inside form

### DIFF
--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -93,13 +93,13 @@ class Profile extends React.Component {
 
         {
           (allowedActions.includes('project.apply') && <Fragment>
-            <p>
-              <form method='POST' action={`/e/${estId}/projects/create`}>
+            <form method='POST' action={`/e/${estId}/projects/create`}>
+              <p>
                 <Button className='govuk-button add-margin'>
                   <Snippet>buttons.pplApply</Snippet>
                 </Button>
-              </form>
-            </p>
+              </p>
+            </form>
           </Fragment>)
         }
 


### PR DESCRIPTION
React was moaning about not being allowed to render a `<form>` inside a `<p>`. Fixing this by reversing the order resolved the weird href values being inserted into links elsewhere.

I have no idea why.