### PR TITLE
Fix comment lookup on named role task review

### DIFF
--- a/pages/task/read/views/role.jsx
+++ b/pages/task/read/views/role.jsx
@@ -55,11 +55,11 @@ const Role = ({ establishment, profile, task, values, formFields, children }) =>
       )
     }
     {
-      (task.data.meta && task.data.meta.comments) && (
+      (task.data.meta && task.data.meta.comment) && (
         <StickyNavAnchor id="comments">
           <Field
             title={<Snippet>sticky-nav.comments</Snippet>}
-            content={task.data.meta.comments}
+            content={task.data.meta.comment}
           />
         </StickyNavAnchor>
       )


### PR DESCRIPTION
It was looking for `comments` but the field is `comment`