### PR TITLE
Remove `<p>` tag wrapping `<h1>` on profile page

### DIFF
--- a/pages/profile/read/views/index.jsx
+++ b/pages/profile/read/views/index.jsx
@@ -10,7 +10,7 @@ const Index = ({
 
   return (
     <Fragment>
-      {model.name && <p><h1>{model.name}</h1></p>}
+      {model.name && <h1>{model.name}</h1>}
       <Profile profile={model} establishment={establishment} title={establishment.name} allowedActions={allowedActions} />
     </Fragment>
   );


### PR DESCRIPTION
React complains about invalid dom nesting, and sets link hrefs to the wrong values when it throws errors.