### PR TITLE
Add type=submit to task confirm page buttons

### DIFF
--- a/pages/task/read/views/confirm.jsx
+++ b/pages/task/read/views/confirm.jsx
@@ -24,7 +24,7 @@ const Confirm = ({ task, values, schema }) => {
           </div>
         }
         <p className="control-panel">
-          <Button><Snippet>buttons.submit</Snippet></Button>
+          <Button type="submit"><Snippet>buttons.submit</Snippet></Button>
           <Link page="task.read" taskId={task.id} label={<Snippet>actions.change</Snippet>} />
         </p>
       </FormLayout>


### PR DESCRIPTION
This wasn't actually submitting the forms before so no tasks could be progressed.