### PR TITLE
Use role type as the POSTed value consistently in managing named roles

### DIFF
--- a/pages/profile/roles/remove/index.js
+++ b/pages/profile/roles/remove/index.js
@@ -37,6 +37,7 @@ module.exports = settings => {
 
   app.post('/confirm', (req, res, next) => {
     const { role, comment } = req.session.form[req.model.id].values;
+    const roleId = req.profile.roles.find(r => r.type === role).id;
 
     const opts = {
       method: 'DELETE',
@@ -46,7 +47,7 @@ module.exports = settings => {
       }
     };
 
-    return req.api(`/establishment/${req.establishmentId}/role/${role}`, opts)
+    return req.api(`/establishment/${req.establishmentId}/role/${roleId}`, opts)
       .then(() => res.redirect(req.buildRoute(`profile.role.remove.success`)))
       .catch(next);
   });

--- a/pages/profile/roles/remove/schema/index.js
+++ b/pages/profile/roles/remove/schema/index.js
@@ -3,7 +3,7 @@ const namedRoles = require('../../content/named-roles');
 module.exports = roles => {
   const options = roles.map(role => {
     return {
-      value: role.id,
+      value: role.type,
       label: namedRoles[role.type]
     };
   });
@@ -14,7 +14,7 @@ module.exports = roles => {
       validate: [
         'required',
         {
-          definedValues: roles.map(r => r.id)
+          definedValues: roles.map(r => r.type)
         }
       ],
       options,


### PR DESCRIPTION
Previously the form to add a named role POSTed a `role` of the role type, but removing POSTed the role id.

This meant that shared code on the confirmation page failed to find the expansion text for the role because it was trying to find it from a database uuid and not a role identifier.

Instead use the type in all cases, and lookup the corresponding database uuid from the profile roles when submitting a removal request to the API.