### PR TITLE
Fix bugs in establishment details page

### DIFF
--- a/pages/establishment/details/views/index.jsx
+++ b/pages/establishment/details/views/index.jsx
@@ -71,36 +71,40 @@ const Index = ({
             {
               (!!killing.length || !!rehomes.length) && <ExpandingPanel title={<Snippet>authorisations.title</Snippet>}>
                 {
-                  !!killing.length && <h2><Snippet>authorisations.killing.title</Snippet></h2>
-                  <dl>
-                    {
-                      killing.map(({ method, description }, index) =>
-                        <div key={index}>
-                          <dt><Snippet>authorisations.killing.method</Snippet></dt>
-                          <dd>{ method }</dd>
+                  !!killing.length && <Fragment>
+                    <h2><Snippet>authorisations.killing.title</Snippet></h2>
+                    <dl>
+                      {
+                        killing.map(({ method, description }, index) =>
+                          <div key={index}>
+                            <dt><Snippet>authorisations.killing.method</Snippet></dt>
+                            <dd>{ method }</dd>
 
-                          <dt><Snippet>authorisations.killing.applicableAnimals</Snippet></dt>
-                          <dd>{ description }</dd>
-                        </div>
-                      )
-                    }
-                  </dl>
+                            <dt><Snippet>authorisations.killing.applicableAnimals</Snippet></dt>
+                            <dd>{ description }</dd>
+                          </div>
+                        )
+                      }
+                    </dl>
+                  </Fragment>
                 }
                 {
-                  !!rehomes.length && <h2><Snippet>authorisations.rehoming.title</Snippet></h2>
-                  <dl>
-                    {
-                      rehomes.map(({ method, description }, index) =>
-                        <Fragment key={index}>
-                          <dt><Snippet>authorisations.rehoming.circumstances</Snippet></dt>
-                          <dd>{ method }</dd>
+                  !!rehomes.length && <Fragment>
+                    <h2><Snippet>authorisations.rehoming.title</Snippet></h2>
+                    <dl>
+                      {
+                        rehomes.map(({ method, description }, index) =>
+                          <Fragment key={index}>
+                            <dt><Snippet>authorisations.rehoming.circumstances</Snippet></dt>
+                            <dd>{ method }</dd>
 
-                          <dt><Snippet>authorisations.rehoming.applicableAnimals</Snippet></dt>
-                          <dd>{ description }</dd>
-                        </Fragment>
-                      )
-                    }
-                  </dl>
+                            <dt><Snippet>authorisations.rehoming.applicableAnimals</Snippet></dt>
+                            <dd>{ description }</dd>
+                          </Fragment>
+                        )
+                      }
+                    </dl>
+                  </Fragment>
                 }
               </ExpandingPanel>
             }

--- a/pages/establishment/details/views/index.jsx
+++ b/pages/establishment/details/views/index.jsx
@@ -23,6 +23,10 @@ const Index = ({
   url,
   ...props
 }) => {
+
+  const killing = authorisations.filter(({ type }) => type === 'killing');
+  const rehomes = authorisations.filter(({ type }) => type === 'rehomes');
+
   return (
     <Fragment>
       <Header
@@ -64,36 +68,42 @@ const Index = ({
                 : <p><Snippet>conditions.noConditions</Snippet></p>
               }
             </ExpandingPanel>
-            <ExpandingPanel title={<Snippet>authorisations.title</Snippet>}>
-              <h2><Snippet>authorisations.killing.title</Snippet></h2>
-              <dl>
+            {
+              (!!killing.length || !!rehomes.length) && <ExpandingPanel title={<Snippet>authorisations.title</Snippet>}>
                 {
-                  authorisations.filter(({ type }) => type === 'killing').map(({ method, description }, index) =>
-                    <div key={index}>
-                      <dt><Snippet>authorisations.killing.method</Snippet></dt>
-                      <dd>{ method }</dd>
+                  !!killing.length && <h2><Snippet>authorisations.killing.title</Snippet></h2>
+                  <dl>
+                    {
+                      killing.map(({ method, description }, index) =>
+                        <div key={index}>
+                          <dt><Snippet>authorisations.killing.method</Snippet></dt>
+                          <dd>{ method }</dd>
 
-                      <dt><Snippet>authorisations.killing.applicableAnimals</Snippet></dt>
-                      <dd>{ description }</dd>
-                    </div>
-                  )
+                          <dt><Snippet>authorisations.killing.applicableAnimals</Snippet></dt>
+                          <dd>{ description }</dd>
+                        </div>
+                      )
+                    }
+                  </dl>
                 }
-              </dl>
-              <h2><Snippet>authorisations.rehoming.title</Snippet></h2>
-              <dl>
                 {
-                  authorisations.filter(({ type }) => type === 'rehomes').map(({ method, description }, index) =>
-                    <Fragment key={index}>
-                      <dt><Snippet>authorisations.rehoming.circumstances</Snippet></dt>
-                      <dd>{ method }</dd>
+                  !!rehomes.length && <h2><Snippet>authorisations.rehoming.title</Snippet></h2>
+                  <dl>
+                    {
+                      rehomes.map(({ method, description }, index) =>
+                        <Fragment key={index}>
+                          <dt><Snippet>authorisations.rehoming.circumstances</Snippet></dt>
+                          <dd>{ method }</dd>
 
-                      <dt><Snippet>authorisations.rehoming.applicableAnimals</Snippet></dt>
-                      <dd>{ description }</dd>
-                    </Fragment>
-                  )
+                          <dt><Snippet>authorisations.rehoming.applicableAnimals</Snippet></dt>
+                          <dd>{ description }</dd>
+                        </Fragment>
+                      )
+                    }
+                  </dl>
                 }
-              </dl>
-            </ExpandingPanel>
+              </ExpandingPanel>
+            }
           </Accordion>
         </div>
       </div>

--- a/pages/establishment/details/views/index.jsx
+++ b/pages/establishment/details/views/index.jsx
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
+import ReactMarkdown from 'react-markdown';
+
 import {
   Accordion,
   ExpandingPanel,
@@ -56,7 +58,7 @@ const Index = ({
                 ? (
                   <Fragment>
                     <p><Snippet>conditions.hasConditions</Snippet></p>
-                    <p>{ conditions }</p>
+                    <ReactMarkdown>{ conditions }</ReactMarkdown>
                   </Fragment>
                 )
                 : <p><Snippet>conditions.noConditions</Snippet></p>


### PR DESCRIPTION
* Use markdown rendering for custom conditions which can be multiple paragraphs in data
* Only show rehoming and killing authorisations sections if there's actually content to be displayed