### PR TITLE
Prevent profiles with no exemptions throwing error on PIL application

### DIFF
--- a/pages/task/read/views/pil.jsx
+++ b/pages/task/read/views/pil.jsx
@@ -44,7 +44,7 @@ const Pil = ({ profile, formFields, task, children }) => {
       <StickyNavAnchor id="training">
         <h2><Snippet>sticky-nav.training</Snippet></h2>
         {
-          profile.certificates.length > 0
+          (profile.certificates && !!profile.certificates.length)
             ? profile.certificates.map((certificate, index) => (
               <div key={index}>
                 <h3><Snippet>pil.training.certificate.details</Snippet></h3>

--- a/pages/task/read/views/pil.jsx
+++ b/pages/task/read/views/pil.jsx
@@ -80,7 +80,7 @@ const Pil = ({ profile, formFields, task, children }) => {
       <StickyNavAnchor id="exemptions">
         <h2><Snippet>sticky-nav.exemptions</Snippet></h2>
         {
-          profile.exemptions.length > 0
+          (profile.exemptions && !!profile.exemptions.length)
             ? profile.exemptions.map((exemption, index) => (
               <div key={index}>
                 <dl>


### PR DESCRIPTION
If `profile.exemptions` is falsy then don't try to read its length.