### PR TITLE
Do not show declarations content in ModelSummary

### DIFF
--- a/pages/place/schema/declarations.js
+++ b/pages/place/schema/declarations.js
@@ -22,6 +22,7 @@ module.exports = {
         return isEqual(optionValues, model.declarations);
       }
     }],
+    show: false,
     showDiff: false
   }
 };


### PR DESCRIPTION
Trying to load a label for the declarations in the model summary component fails because none is defined, but declarations shouldn't be in the model summary anyway.