### PR TITLE
Standardise add and remove named role journeys

### DIFF
--- a/pages/profile/roles/remove/content/index.js
+++ b/pages/profile/roles/remove/content/index.js
@@ -4,7 +4,7 @@ const baseContent = require('../../../content');
 module.exports = merge({}, baseContent, {
   title: 'Amend profile',
   fields: {
-    role: {
+    type: {
       label: 'Please select the role you want to remove.'
     },
     comment: {

--- a/pages/profile/roles/remove/index.js
+++ b/pages/profile/roles/remove/index.js
@@ -36,8 +36,8 @@ module.exports = settings => {
   app.use('/confirm', confirm('remove'));
 
   app.post('/confirm', (req, res, next) => {
-    const { role, comment } = req.session.form[req.model.id].values;
-    const roleId = req.profile.roles.find(r => r.type === role).id;
+    const { type, comment } = req.session.form[req.model.id].values;
+    const roleId = req.profile.roles.find(r => r.type === type).id;
 
     const opts = {
       method: 'DELETE',

--- a/pages/profile/roles/remove/schema/index.js
+++ b/pages/profile/roles/remove/schema/index.js
@@ -9,7 +9,7 @@ module.exports = roles => {
   });
 
   return {
-    role: {
+    type: {
       inputType: 'radioGroup',
       validate: [
         'required',

--- a/pages/profile/roles/views/confirm.jsx
+++ b/pages/profile/roles/views/confirm.jsx
@@ -30,7 +30,7 @@ const Confirm = ({
           <Header title={<Snippet>reviewRoleApplication</Snippet>}/>
 
           <h2><Snippet>applyingFor</Snippet></h2>
-          <p>{namedRoles[values.role]}</p>
+          <p>{namedRoles[values.type]}</p>
 
           <h2><Snippet>onBehalfOf</Snippet></h2>
           <p>{`${profile.firstName} ${profile.lastName}`}</p>


### PR DESCRIPTION
One was using a field name of `role` and the other a field name of `type`. Standardise on `type` because that's what the field is called in the database.