### PR TITLE
Request correct task list

### DIFF
--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -2,24 +2,33 @@ const { get } = require('lodash');
 const defaultSchema = require('./schema');
 const datatable = require('../../common/routers/datatable');
 
+const hasMyTasks = profile => {
+  return profile.asruUser && profile.asru && profile.asru.length > 0;
+};
+
+const tabs = profile => {
+  const options = ['outstanding', 'inProgress', 'completed'];
+  return hasMyTasks(profile) ? ['myTasks', ...options] : options;
+};
+
 module.exports = ({
   apiPath = '/tasks',
-  schema = defaultSchema,
-  tabs = ['myTasks', 'outstanding', 'inProgress', 'completed']
+  schema = defaultSchema
 } = {}) => datatable({
   getApiPath: (req, res, next) => {
-    req.datatable.apiPath = [req.datatable.apiPath, { query: req.query }];
+    const progress = req.query.progress || tabs(req.user.profile)[0];
+    req.datatable.progress = progress;
+    req.datatable.apiPath = [req.datatable.apiPath, { query: { ...req.query, progress } }];
     next();
   },
   locals: (req, res, next) => {
     const firstName = get(req, 'user.profile.firstName');
     const lastName = get(req, 'user.profile.lastName');
     res.locals.static.profileName = `${firstName} ${lastName}`;
-    res.locals.static.progress = req.query.progress;
-    res.locals.datatable.progress = req.query.progress;
+    res.locals.static.progress = req.datatable.progress;
+    res.locals.datatable.progress = req.datatable.progress;
 
-    const isAsru = req.user.profile.asruUser && req.user.profile.asru && req.user.profile.asru.length > 0;
-    res.locals.static.tabs = isAsru ? tabs : tabs.filter(tab => { return tab !== 'myTasks'; });
+    res.locals.static.tabs = tabs(req.user.profile);
     next();
   }
 })({ schema, apiPath });


### PR DESCRIPTION
When a user is requesting their homepage with a "my tasks" tab then the tab was selecting, but the API request was defaulting to "outstanding". Instead explicitly default to the first tab available if none is provided by the query string.