### PR TITLE
Don't render activity log if there's no activity

### DIFF
--- a/pages/task/read/views/activity-log.jsx
+++ b/pages/task/read/views/activity-log.jsx
@@ -76,7 +76,7 @@ class ActivityLog extends Component {
   render() {
     const task = this.props.task;
 
-    if (!task.activityLog) {
+    if (!task.activityLog || task.activityLog.length < 1) {
       return null;
     }
 


### PR DESCRIPTION
Activity log prop might exist but be empty.