### PR TITLE
Revert "Use the model from the task rather than attempting to fetch a potentially deleted model"

### DIFF
--- a/pages/task/read/routers/view.js
+++ b/pages/task/read/routers/view.js
@@ -116,9 +116,21 @@ module.exports = () => {
         res.locals.static.values = req.user.profile;
         return next();
       }
-    }
 
-    res.locals.static.values = req.task.data.modelData;
+      let est = '';
+      if (model !== 'profile') {
+        est = `/establishment/${req.task.data.data.establishmentId}`;
+      }
+      const id = req.task.data.id;
+      const url = `/${model}/${id}`;
+
+      return req.api(`${est}${url}`)
+        .then(({ json: { data } }) => {
+          res.locals.static.values = data;
+        })
+        .then(() => next())
+        .catch(next);
+    }
     next();
   });
 

--- a/pages/task/read/routers/view.js
+++ b/pages/task/read/routers/view.js
@@ -124,7 +124,7 @@ module.exports = () => {
       const id = req.task.data.id;
       const url = `/${model}/${id}`;
 
-      return req.api(`${est}${url}`)
+      return req.api(`${est}${url}?withDeleted=true`)
         .then(({ json: { data } }) => {
           res.locals.static.values = data;
         })


### PR DESCRIPTION
Reverts UKHomeOffice/asl-pages#370

Reverting as we still need to fetch the model to retain eager loaded relations (nacwo in places) - will pass a `withDeleted=true` param to the api to return deleted models