### PR TITLE
Fix validation messages on named roles

### DIFF
--- a/pages/profile/roles/apply/content/index.js
+++ b/pages/profile/roles/apply/content/index.js
@@ -19,7 +19,7 @@ module.exports = merge({}, baseContent, {
     submit: 'Continue'
   },
   errors: {
-    role: {
+    type: {
       required: 'Please select a named role'
     }
   }

--- a/pages/profile/roles/remove/content/index.js
+++ b/pages/profile/roles/remove/content/index.js
@@ -15,7 +15,7 @@ module.exports = merge({}, baseContent, {
     submit: 'Continue'
   },
   errors: {
-    role: {
+    type: {
       required: 'Please select a named role'
     }
   }


### PR DESCRIPTION
The role field was keyed incorrectly when defining the messages so the page threw instead of showing a message.