### PR TITLE
Protect against undefined paths in project data lookup

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -132,6 +132,9 @@ const getNode = (tree, path) => {
   let node = tree[keys[0]];
   for (let i = 1; i < keys.length; i++) {
     let parent = node;
+    if (!parent) {
+      return;
+    }
     if (isUUID(keys[i])) {
       if (parent instanceof Array) {
         node = parent.find(o => o.id === keys[i]);


### PR DESCRIPTION
When finding paths from the current version data in a previous version it is possible that the path does not exist, and if this is the case then currently an error is thrown.

Instead check each fragment of the path is available before attempting to traverse down, and if any segment is undefined then return early with no value.