### PR TITLE
Check NACWO exists before trying to format it

### DIFF
--- a/pages/place/formatters/index.jsx
+++ b/pages/place/formatters/index.jsx
@@ -12,7 +12,7 @@ export default {
     mapOptions: labelFromCode
   },
   nacwo: {
-    format: val => `${val.firstName} ${val.lastName}`,
+    format: val => val && `${val.firstName} ${val.lastName}`,
     accessor: 'id'
   }
 };


### PR DESCRIPTION
It's possible to have a place with no NACWO, which throws at the moment because the no NACWO doesn't have a name. Instead check the NACWO exists before trying to read their name.