### PR TITLE
Add a revoked tab to establishment project list page

### DIFF
--- a/pages/project/content/index.js
+++ b/pages/project/content/index.js
@@ -38,6 +38,7 @@ module.exports = {
   status: {
     active: 'Active',
     expired: 'Expired',
+    revoked: 'Revoked',
     inactive: 'Drafts'
   }
 };

--- a/pages/project/list/views/index.jsx
+++ b/pages/project/list/views/index.jsx
@@ -16,6 +16,7 @@ import formatters from '../../formatters';
 const tabs = [
   'active',
   'expired',
+  'revoked',
   'inactive'
 ];
 


### PR DESCRIPTION
Otherwise there's no way for a user to see revoked projects.