### PR TITLE
Only show active licences in people list

### DIFF
--- a/pages/profile/list/index.js
+++ b/pages/profile/list/index.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash');
+const { get, some } = require('lodash');
 const { page } = require('@asl/service/ui');
 const datatable = require('../../common/routers/datatable');
 const schema = require('./schema');
@@ -20,7 +20,7 @@ module.exports = settings => {
         if (profile.pil && profile.pil.status === 'active') {
           roles.push({ type: 'pilh' });
         }
-        if (profile.projects && profile.projects.length) {
+        if (profile.projects && profile.projects.length && some(profile.projects, p => p.status === 'active')) {
           roles.push({ type: 'pplh' });
         }
         if (get(profile, 'establishments[0].role') === 'admin') {

--- a/pages/profile/list/views/index.jsx
+++ b/pages/profile/list/views/index.jsx
@@ -34,7 +34,9 @@ export const peopleFormatters = {
     format: data => data && joinAcronyms(data.map(selectivelyUppercase))
   },
   pil: {
-    format: data => data || '-'
+    format: (pil, row) => {
+      return (pil && row.pil.status === 'active') ? pil : '-';
+    }
   }
 };
 


### PR DESCRIPTION
When showing PIL numbers and licence holder roles, make sure the licences are active.