### PR TITLE
Changes to inline states

### DIFF
--- a/pages/profile/read/content/index.js
+++ b/pages/profile/read/content/index.js
@@ -41,12 +41,11 @@ module.exports = {
       incomplete: 'Application started.',
       notStarted: 'None'
     },
-    cantApply: 'Can\'t apply for licence',
     noDob: {
-      ownProfile: 'All licence applicants need a valid date of birth. Please add this information to your account before you apply for a licence.',
-      otherProfile: 'All licence applicants need a valid date of birth. Contact the applicant to update their account before applying for a licence on their behalf.'
+      ownProfile: 'Please add your date of birth to your account.',
+      otherProfile: 'Ask the applicant to add their date of birth to their account.'
     },
-    under18: 'All licence applicants must be over 18.',
-    addDob: 'Add this information to your account'
+    under18: 'Personal licence holders must be over 18.',
+    addDob: 'Please add your date of birth to your account.'
   }
 };

--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -170,7 +170,7 @@ class Profile extends React.Component {
                 )
               }
               {
-                !pil && (
+                !pil && over18 && (
                   <p>
                     <Snippet>pil.noPil</Snippet>
                   </p>
@@ -186,16 +186,15 @@ class Profile extends React.Component {
               {
                 (!dob || !over18) && (
                   <Fragment>
-                    <p>
-                      {
-                        !dob &&
-                          <Fragment>
-                            <Snippet>{`pil.noDob.${isOwnProfile ? 'ownProfile' : 'otherProfile'}`}</Snippet>
-                          </Fragment>
-                      }
-                      { dob && !over18 && <Snippet>pil.under18</Snippet> }
-                    </p>
-                    { !dob && isOwnProfile && <p><Link page='account.edit' label={<Snippet>pil.addDob</Snippet>} /></p> }
+                    {
+                      dob && !over18 && <p><Snippet>pil.under18</Snippet></p>
+                    }
+                    {
+                      !dob && <p><Snippet>{`pil.noDob.${isOwnProfile ? 'ownProfile' : 'otherProfile'}`}</Snippet></p>
+                    }
+                    {
+                      !dob && isOwnProfile && <p><Link page='account.edit' label={<Snippet>pil.addDob</Snippet>} /></p>
+                    }
                   </Fragment>
                 )
               }

--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -186,7 +186,6 @@ class Profile extends React.Component {
               {
                 (!dob || !over18) && (
                   <Fragment>
-                    <p><strong><Snippet>pil.cantApply</Snippet></strong></p>
                     <p>
                       {
                         !dob &&


### PR DESCRIPTION
The default text for noDob, under18, and addDob have been changed.

I have removed the 'Can't apply for licence' heading.

Note that the logic here needs changing. The only time that 'None' would display in this component is if a user has a DoB in their account, is over 18, but has not yet applied for a PIL. In all other cases, 'None' should be omitted.