### PR TITLE
Use API call to load establishment data on invite page

### DIFF
--- a/pages/profile/invite/index.js
+++ b/pages/profile/invite/index.js
@@ -12,9 +12,12 @@ module.exports = settings => {
 
   app.use('/', (req, res, next) => {
     req.breadcrumb('profile.invite');
-    const establishment = req.user.profile.establishments.find(e => e.id === req.establishmentId);
-    res.locals.static.establishment = establishment;
-    next();
+    return req.api(`/establishment/${req.establishmentId}`)
+      .then(response => {
+        res.locals.static.establishment = response.json.data;
+        next();
+      })
+      .catch(next);
   });
 
   app.post('/', (req, res, next) => {


### PR DESCRIPTION
This functionality has been extended to ASRU users, which means the establishment cannot be loaded from the users profile as it does not exist there for ASRU users.

Instead make an API call to load the establishment data.