### PR TITLE
Last change before go live

### DIFF
--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -18,7 +18,7 @@ module.exports = {
   'sticky-nav': {
     activity: 'Latest activity',
     establishment: 'Establishment details',
-    comments: 'Comments',
+    comments: 'Reason for amendment',
     status: 'What do you want to do?',
     conditions: 'Additional conditions',
     withdraw: 'Withdraw {{type}}'


### PR DESCRIPTION
Anything else can wait.

I assume this changes the heading in the left-hand nav AND the page body on task review pages.

This currently only appears on amendments, but we may need to have alternate versions when revocations, suspensions etc become things.