### PR TITLE
Render null dates correctly on profile update tasks

### DIFF
--- a/pages/task/read/views/profile.jsx
+++ b/pages/task/read/views/profile.jsx
@@ -10,7 +10,7 @@ import MakeDecision from './make-decision';
 
 const formatters = {
   dob: {
-    format: date => format(date, dateFormat.short)
+    format: date => date ? format(date, dateFormat.short) : '-'
   }
 };
 


### PR DESCRIPTION
If a user has no current date of birth then the date format function renders "1st january 1970". Instead it should render a `-`.