### PR TITLE
Don't require NACWO to be defined on a place amendment

### DIFF
--- a/pages/place/schema/index.js
+++ b/pages/place/schema/index.js
@@ -48,8 +48,7 @@ const baseSchema = {
   },
   nacwo: {
     inputType: 'select',
-    accessor: 'id',
-    validate: ['required']
+    accessor: 'id'
   }
 };
 


### PR DESCRIPTION
ASRU want to be able to edit restrictions on places, but because none of them have NACWOs they can't do it because they're not able to assign NACWOs.

Un-require NACWO to be set in order to allow ASRU to edit.