### PR TITLE
Fix NACWO validation

### DIFF
--- a/pages/place/schema/index.js
+++ b/pages/place/schema/index.js
@@ -61,9 +61,9 @@ const mapSchema = (nacwos, schema) => {
     nacwo: {
       options,
       validate: [
-        ...schema.nacwo.validate,
+        ...(schema.nacwo.validate || []),
         {
-          definedValues: options.map(option => option.value)
+          definedValues: options.map(option => option.value).concat([''])
         }
       ]
     }


### PR DESCRIPTION
`schema.nacwo.validate` is undefined so was throwing an error.

The `definedValues` validator needs to allow no value being set.