### PR TITLE
Handle workflow connection errors

### DIFF
--- a/pages/common/components/in-progress-warning.jsx
+++ b/pages/common/components/in-progress-warning.jsx
@@ -3,7 +3,15 @@ import { Link } from '@asl/components';
 
 export default ({ task }) => {
   return <Fragment>
-    <p>This item cannot be edited as it is currently being amended.</p>
-    <p><Link page="task.read" taskId={task.id} label="View task" /></p>
+    {
+      task.action === 'failed'
+        ? <p>Due to a problem with the service this item cannot be edited. Please try again later.</p>
+        : (
+          <Fragment>
+            <p>This item cannot be edited as it is currently being amended.</p>
+            <p><Link page="task.read" taskId={task.id} label="View task" /></p>
+          </Fragment>
+        )
+    }
   </Fragment>;
 };

--- a/pages/common/components/in-progress-warning.jsx
+++ b/pages/common/components/in-progress-warning.jsx
@@ -2,16 +2,13 @@ import React, { Fragment } from 'react';
 import { Link } from '@asl/components';
 
 export default ({ task }) => {
-  return <Fragment>
-    {
-      task.action === 'failed'
-        ? <p>Due to a problem with the service this item cannot be edited. Please try again later.</p>
-        : (
-          <Fragment>
-            <p>This item cannot be edited as it is currently being amended.</p>
-            <p><Link page="task.read" taskId={task.id} label="View task" /></p>
-          </Fragment>
-        )
-    }
-  </Fragment>;
+  if (task.action === 'failed') {
+    return <p>Due to a problem with the service this item cannot be edited. Please try again later.</p>;
+  }
+  return (
+    <Fragment>
+      <p>This item cannot be edited as it is currently being amended.</p>
+      <p><Link page="task.read" taskId={task.id} label="View task" /></p>
+    </Fragment>
+  );
 };

--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -36,7 +36,8 @@ module.exports = ({
   getApiPath = defaultMiddleware,
   getValues = defaultMiddleware,
   persistQuery = defaultMiddleware,
-  locals = defaultMiddleware
+  locals = defaultMiddleware,
+  errorHandler = (err, req, res, next) => next(err)
 } = {}) => ({
   apiPath,
   schema,
@@ -108,16 +109,13 @@ module.exports = ({
         if (meta.establishment) {
           res.establishment = meta.establishment;
         }
-        const { filters, total, count, ...rest } = meta;
 
-        set(req.datatable, 'filters.options', filters);
-        set(req.datatable, 'pagination.totalCount', total);
-        set(req.datatable, 'pagination.count', count);
+        set(req.datatable, 'filters.options', meta.filters);
+        set(req.datatable, 'pagination.totalCount', meta.total);
+        set(req.datatable, 'pagination.count', meta.count);
         set(req.datatable, 'data.rows', data.map(cleanModel));
 
-        Object.assign(req.datatable, rest || {});
-
-        if (!data.length && count) {
+        if (!data.length && meta.count) {
           const redirect = removeQueryParams(req.originalUrl, ['page', 'rows']);
           res.redirect(redirect);
         }
@@ -142,6 +140,8 @@ module.exports = ({
     _getValues,
     _locals
   );
+
+  app.use(errorHandler);
 
   return app;
 };

--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -108,13 +108,16 @@ module.exports = ({
         if (meta.establishment) {
           res.establishment = meta.establishment;
         }
+        const { filters, total, count, ...rest } = meta;
 
-        set(req.datatable, 'filters.options', meta.filters);
-        set(req.datatable, 'pagination.totalCount', meta.total);
-        set(req.datatable, 'pagination.count', meta.count);
+        set(req.datatable, 'filters.options', filters);
+        set(req.datatable, 'pagination.totalCount', total);
+        set(req.datatable, 'pagination.count', count);
         set(req.datatable, 'data.rows', data.map(cleanModel));
 
-        if (!data.length && meta.count) {
+        Object.assign(req.datatable, rest || {});
+
+        if (!data.length && count) {
           const redirect = removeQueryParams(req.originalUrl, ['page', 'rows']);
           res.redirect(redirect);
         }

--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -12,5 +12,6 @@ module.exports = {
     inProgress: 'In progress',
     completed: 'Completed',
     myTasks: 'My tasks'
-  }
+  },
+  'tasklist-unavailable': 'Task list unavailable'
 };

--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -21,12 +21,16 @@ module.exports = ({
     req.datatable.apiPath = [req.datatable.apiPath, { query: { ...req.query, progress } }];
     next();
   },
+  errorHandler: (err, req, res, next) => {
+    req.log('error', { ...err, message: err.message, stack: err.stack });
+    res.locals.static.workflowConnectionError = true;
+    next();
+  },
   locals: (req, res, next) => {
     const firstName = get(req, 'user.profile.firstName');
     const lastName = get(req, 'user.profile.lastName');
     res.locals.static.profileName = `${firstName} ${lastName}`;
     res.locals.static.progress = req.datatable.progress;
-    res.locals.static.workflowConnectionError = req.datatable.connectionError;
     res.locals.datatable.progress = req.datatable.progress;
 
     res.locals.static.tabs = tabs(req.user.profile);

--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -26,6 +26,7 @@ module.exports = ({
     const lastName = get(req, 'user.profile.lastName');
     res.locals.static.profileName = `${firstName} ${lastName}`;
     res.locals.static.progress = req.datatable.progress;
+    res.locals.static.workflowConnectionError = req.datatable.connectionError;
     res.locals.datatable.progress = req.datatable.progress;
 
     res.locals.static.tabs = tabs(req.user.profile);

--- a/pages/task/list/views/index.jsx
+++ b/pages/task/list/views/index.jsx
@@ -5,22 +5,15 @@ import {
   Header,
   Snippet
 } from '@asl/components';
-import TaskListUnavilable from './tasklist-unavailable';
 
-const TaskListPage = ({ name, progress, tabs, workflowConnectionError }) => (
+const TaskListPage = ({ profileName }) => (
   <Fragment>
     <Header
       title={<Snippet>title</Snippet>}
-      subtitle={name}
+      subtitle={profileName}
     />
-    {
-      workflowConnectionError
-        ? <TaskListUnavilable />
-        : <TaskList tabs={ tabs } progress={ progress } />
-    }
+    <TaskList />
   </Fragment>
 );
 
-const mapStateToProps = ({ static: { profileName: name, progress, tabs, workflowConnectionError } }) => ({ name, progress, tabs, workflowConnectionError });
-
-export default connect(mapStateToProps)(TaskListPage);
+export default connect(({ static: { profileName } }) => ({ profileName }))(TaskListPage);

--- a/pages/task/list/views/index.jsx
+++ b/pages/task/list/views/index.jsx
@@ -5,17 +5,22 @@ import {
   Header,
   Snippet
 } from '@asl/components';
+import TaskListUnavilable from './tasklist-unavailable';
 
-const TaskListPage = ({ name, progress, tabs }) => (
+const TaskListPage = ({ name, progress, tabs, workflowConnectionError }) => (
   <Fragment>
     <Header
       title={<Snippet>title</Snippet>}
       subtitle={name}
     />
-    <TaskList tabs={ tabs } progress={ progress } />
+    {
+      workflowConnectionError
+        ? <TaskListUnavilable />
+        : <TaskList tabs={ tabs } progress={ progress } />
+    }
   </Fragment>
 );
 
-const mapStateToProps = ({ static: { profileName: name, progress, tabs } }) => ({ name, progress, tabs });
+const mapStateToProps = ({ static: { profileName: name, progress, tabs, workflowConnectionError } }) => ({ name, progress, tabs, workflowConnectionError });
 
 export default connect(mapStateToProps)(TaskListPage);

--- a/pages/task/list/views/tasklist-unavailable.jsx
+++ b/pages/task/list/views/tasklist-unavailable.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-import {
-  Panel,
-  Snippet
-} from '@asl/components';
-
-export default () => <Panel><h2><Snippet>tasklist-unavailable</Snippet></h2></Panel>;

--- a/pages/task/list/views/tasklist-unavailable.jsx
+++ b/pages/task/list/views/tasklist-unavailable.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import {
+  Panel,
+  Snippet
+} from '@asl/components';
+
+export default () => <Panel><h2><Snippet>tasklist-unavailable</Snippet></h2></Panel>;

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 import get from 'lodash/get';
 import { formatDate } from '../../../../lib/utils';
@@ -7,7 +8,8 @@ import {
   Tabs,
   Datatable,
   Snippet,
-  Link
+  Link,
+  Panel
 } from '@asl/components';
 
 const good = ['resolved'];
@@ -73,22 +75,37 @@ const formatters = {
   }
 };
 
-class Tasklist extends React.Component {
-
-  render() {
-    const tabs = this.props.tabs || [];
-    const progress = this.props.progress || tabs[0];
-    const selected = tabs.indexOf(progress);
-    return <Fragment>
+const Tasklist = ({
+  workflowConnectionError,
+  tabs = [],
+  progress
+}) => {
+  progress = progress || tabs[0];
+  const selected = tabs.indexOf(progress);
+  return (
+    <Fragment>
       {
-        !!tabs.length && <Tabs active={selected}>
-          { tabs.map(tab => <a key={tab} href={`?progress=${tab}`}><Snippet>{ `tabs.${tab}` }</Snippet></a>) }
-        </Tabs>
+        workflowConnectionError
+          ? (
+            <Panel>
+              <h2>
+                <Snippet>tasklist-unavailable</Snippet>
+              </h2>
+            </Panel>
+          )
+          : (
+            <Fragment>
+              {
+                !!tabs.length && <Tabs active={selected}>
+                  { tabs.map(tab => <a key={tab} href={`?progress=${tab}`}><Snippet>{ `tabs.${tab}` }</Snippet></a>) }
+                </Tabs>
+              }
+              <Datatable formatters={formatters} className="tasklist" />
+            </Fragment>
+          )
       }
-      <Datatable formatters={formatters} className="tasklist" />
-    </Fragment>;
-  }
+    </Fragment>
+  );
+};
 
-}
-
-export default Tasklist;
+export default connect(({ static: { workflowConnectionError, tabs, progress } }) => ({ workflowConnectionError, tabs, progress }))(Tasklist);

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -80,30 +80,25 @@ const Tasklist = ({
   tabs = [],
   progress
 }) => {
+  if (workflowConnectionError) {
+    return (
+      <Panel>
+        <h2>
+          <Snippet>tasklist-unavailable</Snippet>
+        </h2>
+      </Panel>
+    );
+  }
   progress = progress || tabs[0];
   const selected = tabs.indexOf(progress);
   return (
     <Fragment>
       {
-        workflowConnectionError
-          ? (
-            <Panel>
-              <h2>
-                <Snippet>tasklist-unavailable</Snippet>
-              </h2>
-            </Panel>
-          )
-          : (
-            <Fragment>
-              {
-                !!tabs.length && <Tabs active={selected}>
-                  { tabs.map(tab => <a key={tab} href={`?progress=${tab}`}><Snippet>{ `tabs.${tab}` }</Snippet></a>) }
-                </Tabs>
-              }
-              <Datatable formatters={formatters} className="tasklist" />
-            </Fragment>
-          )
+        !!tabs.length && <Tabs active={selected}>
+          { tabs.map(tab => <a key={tab} href={`?progress=${tab}`}><Snippet>{ `tabs.${tab}` }</Snippet></a>) }
+        </Tabs>
       }
+      <Datatable formatters={formatters} className="tasklist" />
     </Fragment>
   );
 };


### PR DESCRIPTION
If workflow is unavailable the api now still responds but with a connectionError if trying to load all tasks, and a single task with action: 'failed' when fetching open tasks for a model.

Handle these cases by showing an alternate component for the tasklist and different message when trying to edit a model