### PR TITLE
Clear session on task success

### DIFF
--- a/pages/task/index.js
+++ b/pages/task/index.js
@@ -8,6 +8,7 @@ module.exports = settings => {
   app.param('taskId', (req, res, next, taskId) => {
     return req.api(`/tasks/${taskId}`)
       .then(response => {
+        req.taskId = taskId;
         req.task = response.json.data;
       })
       .then(() => next())

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -9,6 +9,10 @@ module.exports = () => {
   app.use((req, res, next) => {
     req.breadcrumb('task.confirm');
     req.model = { id: req.task.id };
+    const status = get(req, `session.form[${req.task.id}].values.status`);
+    if (!status) {
+      return res.redirect(req.buildRoute('task.read'));
+    }
     next();
   });
 
@@ -52,7 +56,7 @@ module.exports = () => {
   });
 
   app.post('/', (req, res, next) => {
-    return res.redirect(req.buildRoute('task.success', { taskId: req.task.id }));
+    return res.redirect(req.buildRoute('task.success'));
   });
 
   return app;

--- a/pages/task/read/routers/success.js
+++ b/pages/task/read/routers/success.js
@@ -12,7 +12,8 @@ module.exports = () => {
   });
 
   app.use((req, res, next) => {
-    const status = get(req.session, `form.${req.model.id}.values.status`);
+    const id = req.model.id;
+    const status = get(req.session, `form.${id}.values.status`, get(req.session, `form.${id}.values.storeStatus`));
     req.status = status;
     res.locals.static.profile = req.task.data.changedBy;
     next();
@@ -28,8 +29,11 @@ module.exports = () => {
   });
 
   app.get('/', (req, res, next) => {
-    const status = get(req.session, `form[${req.model.id}].values.status`);
-    set(req.session, `form.${req.model.id}.values.status`, status);
+    const id = req.model.id;
+    delete req.session.form[id];
+    // we need to clear the session so previous form values aren't
+    // persisted, however we need to use the status if page is refreshed
+    set(req.session, `form.${id}.values.storeStatus`, req.status);
     next();
   });
 


### PR DESCRIPTION
We were not clearing session on task success, so the next time around status and comments were being persisted.

Added redirect to confirm page - users should not be able to visit this page once the task has been actioned