### PR TITLE
Fix ASRU users viewing granted PPLs

### DIFF
--- a/pages/project-version/read/index.js
+++ b/pages/project-version/read/index.js
@@ -31,7 +31,7 @@ module.exports = settings => {
       : req.version.status === 'granted';
 
     res.locals.static.editConditions = req.user.profile.asruUser &&
-      task.withASRU &&
+      task && task.withASRU &&
       req.version.status === 'submitted' &&
       req.project.versions[0].id === req.version.id;
 


### PR DESCRIPTION
If an open task does not exist then this condition throws. This means ASRU users cannot currently view granted PPLs.