### PR TITLE
Check sort column exists in schema before trying to apply

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -20,7 +20,7 @@ const buildQuery = (req, schema) => {
     search = search[0];
   }
 
-  if (sort && sort.column) {
+  if (sort && sort.column && schema[sort.column]) {
     if (schema[sort.column].sort) {
       sort.column = schema[sort.column].sort;
     } else if (schema[sort.column].accessor) {


### PR DESCRIPTION
If an internal user has sorted their task list then the query string will contain the sort fields. If they then search then the task list sort order tries to apply to the establishment search and fails because it's sorting a column that doesn't exist.

Check it exists first.