### PR TITLE
Don't rewrite task actions on project grant

### DIFF
--- a/pages/task/read/middleware/update-data.js
+++ b/pages/task/read/middleware/update-data.js
@@ -10,10 +10,6 @@ module.exports = (req, res, next) => {
   let id = get(req.task, 'data.id');
   let action = get(req.task, 'data.action');
 
-  if (action === 'grant') {
-    action = 'update';
-  }
-
   if (model === 'profile') {
     model = 'account';
   }
@@ -33,11 +29,13 @@ module.exports = (req, res, next) => {
   if (model === 'project') {
     if (action === 'grant') {
       model = 'project.version';
-
+      action = 'update';
       params.versionId = req.project.draft.id;
     } else if (action === 'update') {
       action = 'updateLicenceHolder';
     }
+  } else if (action === 'grant') {
+    action = 'update';
   }
 
   return res.redirect(req.buildRoute(`${model}.${action}`, params));


### PR DESCRIPTION
The mapping of grant action to update was only meant to apply to PILs but it was also mapping project grant actions, which meant the condition further down the file was being missed and projects were redirecting incorrectly.

Move the mapping for not-projects into an else-if so that projects are handled correctly.