### PR TITLE
Preserve existing profile on success pages

### DIFF
--- a/pages/common/routers/success.js
+++ b/pages/common/routers/success.js
@@ -19,7 +19,7 @@ module.exports = ({
     }
     const success = get(successContent, `${licence}.${type}.${status}`);
     merge(res.locals.static.content, { success });
-    res.locals.static.profile = req.user.profile;
+    res.locals.static.profile = res.locals.static.profile || req.user.profile;
     next();
   });
 

--- a/pages/pil/create/index.js
+++ b/pages/pil/create/index.js
@@ -18,8 +18,12 @@ module.exports = settings => {
   });
 
   app.use((req, res, next) => {
+    req.breadcrumb('pil.create');
     if (!req.profile.pil) {
-      req.breadcrumb('pil.create');
+      return next();
+    }
+    // allow new application if a revoked PIL is held by another establishment
+    if (req.profile.pil.status === 'revoked' && req.profile.pil.establishmentId !== req.establishmentId) {
       return next();
     }
     res.redirect(req.buildRoute('pil.read', { pilId: req.profile.pil.id }));


### PR DESCRIPTION
If performaing an action on someone else's behalf then the profile name in the breadcrumb is replaced by the current user in the success page. This could easily lead to confusion.