### PR TITLE
Add project title as a title attribute to project tasks

### DIFF
--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -62,9 +62,11 @@ const formatters = {
       }
 
       let contextLabel = null;
+      let title = null
 
       switch (licence) {
         case 'project':
+          title = get(model, 'data.modelData.title');
         case 'pil':
         case 'role':
         case 'profile':
@@ -83,7 +85,7 @@ const formatters = {
       }
 
       return (
-        <Fragment>
+        <div title={title}>
           <Link
             page="task.read"
             taskId={id}
@@ -98,7 +100,7 @@ const formatters = {
                 <span>{contextLabel}</span>
               </Fragment>
           }
-        </Fragment>
+        </div>
       );
     }
   }

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -64,7 +64,7 @@ const formatters = {
       let contextLabel = null;
       let title = null;
       if (licence === 'project') {
-        title = get(model, 'data.modelData.title', 'Untitled project');
+        title = get(model, 'data.modelData.title') || 'Untitled project';
       }
 
       switch (licence) {

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -66,7 +66,7 @@ const formatters = {
 
       switch (licence) {
         case 'project':
-          title = get(model, 'data.modelData.title');
+          title = get(model, 'data.modelData.title', 'Untitled project');
         case 'pil':
         case 'role':
         case 'profile':

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -62,11 +62,13 @@ const formatters = {
       }
 
       let contextLabel = null;
-      let title = null
+      let title = null;
+      if (licence === 'project') {
+        title = get(model, 'data.modelData.title', 'Untitled project');
+      }
 
       switch (licence) {
         case 'project':
-          title = get(model, 'data.modelData.title', 'Untitled project');
         case 'pil':
         case 'role':
         case 'profile':


### PR DESCRIPTION
This allows for disambiguation between multiple PPL tasks where the PPL holder is the same. Specifically in automated tests.