### PR TITLE
Allow importing .txt files as PPLs

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -1,4 +1,4 @@
-const { isUndefined, isNull, every, castArray } = require('lodash');
+const { isUndefined, isNull, every, castArray, some } = require('lodash');
 const moment = require('moment');
 
 const validators = {
@@ -71,6 +71,9 @@ const validators = {
     return every(files, file => castArray(types).includes(file.mimetype));
   },
   ext(files, ext) {
+    if (Array.isArray(ext)) {
+      return some(ext, e => validators.ext(files, e));
+    }
     const ra = new RegExp(`\\.${ext}$`);
     return every(files, file => file.originalname.match(ra));
   }

--- a/pages/project/import/schema/index.js
+++ b/pages/project/import/schema/index.js
@@ -11,7 +11,12 @@ module.exports = {
           'text/plain'
         ]
       },
-      { ext: 'ppl' }
+      {
+        ext: [
+          'ppl',
+          'txt'
+        ]
+      }
     ]
   }
 };


### PR DESCRIPTION
There's some browser/OS combination that when downloading a .ppl file modifies the file extension to .txt, which means that the downloaded files cannot be imported.

Add an extra allowed file extension to the import validator so that it can support these files as well.