### PR TITLE
Use updated at instead of created at timestamp for invitation list

### DIFF
--- a/pages/profile/invitations/schema/index.js
+++ b/pages/profile/invitations/schema/index.js
@@ -5,7 +5,7 @@ module.exports = {
   role: {
     show: true
   },
-  createdAt: {
+  updatedAt: {
     show: true
   }
 };

--- a/pages/profile/invitations/views/index.jsx
+++ b/pages/profile/invitations/views/index.jsx
@@ -10,7 +10,7 @@ const formatters = {
   role: {
     format: role => <Snippet>{`fields.role.options.${role}.label`}</Snippet>
   },
-  createdAt: {
+  updatedAt: {
     format: date => date ? <ExpiryDate
       date={date}
       expiry={addDays(date, 7)}


### PR DESCRIPTION
Is re-issuing an invitation then the original invitation is updated, so the timestamp in the table needs to show the re-issue date not the original date.