### PR TITLE
Set default sort order on invitations list

### DIFF
--- a/pages/profile/invitations/index.js
+++ b/pages/profile/invitations/index.js
@@ -11,7 +11,7 @@ module.exports = settings => {
   app.use((req, res, next) => {
     req.datatable = {
       sort: {
-        column: 'createdAt',
+        column: 'updatedAt',
         ascending: false
       }
     };


### PR DESCRIPTION
Table should be sorted by updatedAt not createdAt by default.