### PR TITLE
Bugfix - show version on resubmitted events

### DIFF
--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -34,7 +34,7 @@ const getRecommendation = status => {
 
 const ExtraProjectMeta = ({ item, task }) => {
   const status = item.event.status;
-  if (status !== 'with-inspectorate') {
+  if (status !== 'with-inspectorate' && status !== 'resubmitted') {
     return null;
   }
   const versionId = get(item, 'event.data.data.version');


### PR DESCRIPTION
* Resubmitted events should include a link to the submitted version