### PR TITLE
Handle revocations as well as applications and amendments

### DIFF
--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -78,11 +78,12 @@ function OpenTask({ model }) {
   }
 
   let type = model.status === 'inactive' ? 'application' : 'amendment';
-  const status = type;
 
   if (openTask.data.action === 'revoke') {
     type = 'revocation';
   }
+
+  const status = type;
 
   if (openTask.data.action === 'update') {
     type = 'update-licence-holder';


### PR DESCRIPTION
The task type is currently stored before revocations are processed so revocations end up being incorrectly described as amendments.

Move the revocation case to before the type is mapped onto status.