### PR TITLE
Hide task list and filters when there are no tasks

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -13,5 +13,11 @@ module.exports = {
     completed: 'Completed',
     myTasks: 'My tasks'
   },
+  'no-tasks': {
+    outstanding: 'You have no outstanding tasks',
+    inProgress: 'You have no tasks in progress',
+    completed: 'You have no completed tasks',
+    myTasks: 'There are no tasks assigned to you'
+  },
   'tasklist-unavailable': 'Task list unavailable'
 };

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -131,7 +131,8 @@ const Filters = () => (
 const Tasklist = ({
   workflowConnectionError,
   tabs = [],
-  progress
+  progress,
+  hasTasks
 }) => {
   if (workflowConnectionError) {
     return (
@@ -151,10 +152,37 @@ const Tasklist = ({
           { tabs.map(tab => <a key={tab} href={`?progress=${tab}`}><Snippet>{ `tabs.${tab}` }</Snippet></a>) }
         </Tabs>
       }
-      <Filters />
-      <Datatable formatters={formatters} className="tasklist" />
+      {
+        hasTasks && <Fragment>
+          <Filters />
+          <Datatable formatters={formatters} className="tasklist" />
+        </Fragment>
+      }
+      {
+        !hasTasks && <p><Snippet>{ `no-tasks.${progress}` }</Snippet></p>
+      }
     </Fragment>
   );
 };
 
-export default connect(({ static: { workflowConnectionError, tabs, progress } }) => ({ workflowConnectionError, tabs, progress }))(Tasklist);
+const mapStateToProps = ({
+  static: {
+    workflowConnectionError,
+    tabs,
+    progress
+  },
+  datatable: {
+    pagination: {
+      totalCount: taskCount
+    }
+  }
+}) => {
+  return {
+    workflowConnectionError,
+    tabs,
+    progress,
+    hasTasks: taskCount > 0
+  };
+};
+
+export default connect(mapStateToProps)(Tasklist);


### PR DESCRIPTION
If there are no tasks to show (before filters are applied) then instead of taking up space with filters, filter summary and an empty table, simply show a "no tasks" message instead.