### PR TITLE
Make sure PIL categories are rendered in order

### DIFF
--- a/pages/pil/read/views/index.jsx
+++ b/pages/pil/read/views/index.jsx
@@ -59,7 +59,7 @@ const PIL = ({
         if (!procedures) {
           return '-';
         }
-        return procedures.map(procedure => {
+        return procedures.sort().map(procedure => {
           return (
             <p key={procedure}>
               <strong>{procedure}</strong>: <Snippet>{`procedureDefinitions.${procedure}`}</Snippet>


### PR DESCRIPTION
This might just be wonky seed data, but the categories don't always display in the correct (alphabetical) order. Sort them before rendering to make sure they're always sensibly ordered.