### PR TITLE
Respond with correct error code in permissions middleware

### DIFF
--- a/lib/middleware/permissions.js
+++ b/lib/middleware/permissions.js
@@ -5,7 +5,7 @@ module.exports = (task, params) => (req, res, next) => {
       if (allowed) {
         return next();
       }
-      const err = new Error('Unauthorised');
+      const err = new Error('Forbidden');
       err.status = 403;
       throw err;
     })

--- a/lib/middleware/permissions.js
+++ b/lib/middleware/permissions.js
@@ -6,7 +6,7 @@ module.exports = (task, params) => (req, res, next) => {
         return next();
       }
       const err = new Error('Unauthorised');
-      err.status = 401;
+      err.status = 403;
       throw err;
     })
     .catch(next);


### PR DESCRIPTION
If a user does not have permission to perform a task then the correct error code is a 403 - which is consistent with the response codes sent by the API layers.