### PR TITLE
Bugfix - protect against falsy array entries

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -63,7 +63,7 @@ const traverse = (node, key, keys = []) => {
   if (key) { keys.push(key); }
   if (node instanceof Array) {
     node.forEach(o => {
-      traverse(o, `${key}${o.id ? `.${o.id}` : ''}`, keys);
+      traverse(o, `${key}${o && o.id ? `.${o.id}` : ''}`, keys);
     });
   } else if (node instanceof Object) {
     Object.keys(node).forEach(k => {


### PR DESCRIPTION
The actual bug manifested by this is where an array contains `null`, which technically should not be possible, however we should not always try and access id from the entry as sometimes we may actually wand falsy entries.