### PR TITLE
Only send one response in datatable normalisation redirect

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -114,13 +114,14 @@ module.exports = ({
         set(req.datatable, 'pagination.totalCount', meta.total);
         set(req.datatable, 'pagination.count', meta.count);
         set(req.datatable, 'data.rows', data.map(cleanModel));
-
-        if (!data.length && meta.count) {
-          const redirect = removeQueryParams(req.originalUrl, ['page', 'rows']);
-          res.redirect(redirect);
-        }
       })
-      .then(() => getValues(req, res, next))
+      .then(() => {
+        if (!req.datatable.data.rows.length && req.datatable.pagination.count) {
+          const redirect = removeQueryParams(req.originalUrl, ['page', 'rows']);
+          return res.redirect(redirect);
+        }
+        getValues(req, res, next);
+      })
       .catch(next);
   };
 


### PR DESCRIPTION
The redirect wasn't preventing the middleware chain from further execution, so would throw an error about sending headers after a response was sent in those cases.

Instead make sure that if the redirect applies then the middleware chain does not continue to execute.