### PR TITLE
Shallow merge PIL procedures and species

### DIFF
--- a/pages/pil/procedures/index.js
+++ b/pages/pil/procedures/index.js
@@ -34,7 +34,7 @@ module.exports = settings => {
 
   app.post('/', (req, res, next) => {
     const procedures = get(req.session, `form[${req.model.id}].values`);
-    req.session.form[req.pil.id].values = merge({}, req.session.form[req.pil.id].values, procedures);
+    req.session.form[req.pil.id].values = Object.assign({}, req.session.form[req.pil.id].values, procedures);
     delete req.session.form[req.pil.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update'));
   });

--- a/pages/pil/species/index.js
+++ b/pages/pil/species/index.js
@@ -23,7 +23,7 @@ module.exports = () => {
 
   app.post('/', (req, res, next) => {
     const species = get(req.session, `form[${req.model.id}].values`);
-    req.session.form[req.pil.id].values = merge({}, req.session.form[req.pil.id].values, species);
+    req.session.form[req.pil.id].values = Object.assign({}, req.session.form[req.pil.id].values, species);
     delete req.session.form[req.pil.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update'));
   });


### PR DESCRIPTION
Because `lodash#merge` performs a deep merge of the old values and the new it's not possible to remove procedures or species from a PIL application.

Instead do a shallow merge so that array values are completely replaced by the new values.