### PR TITLE
Support PDF rendering of null projects

### DIFF
--- a/pages/project-version/pdf/index.jsx
+++ b/pages/project-version/pdf/index.jsx
@@ -15,7 +15,7 @@ module.exports = settings => {
 
   app.get('/', (req, res, next) => {
     const initialState = {
-      project: req.version.data,
+      project: req.version.data || { title: 'Untitled project' },
       application: {
         schemaVersion: req.project.schemaVersion,
         establishment: req.project.establishment,


### PR DESCRIPTION
If a user downloads a PDF of a freshly created project then lots of things fail because the project is `null`. Give it a default value with a default title if the project is completely untouched.