### PR TITLE
Redirect task success pages if session has expired

### DIFF
--- a/pages/task/read/routers/success.js
+++ b/pages/task/read/routers/success.js
@@ -13,6 +13,9 @@ module.exports = () => {
   app.use((req, res, next) => {
     const id = req.model.id;
     const status = get(req.session, `form.${id}.values.status`, get(req.session, `form.${id}.values.storeStatus`));
+    if (!status) {
+      return res.redirect(req.buildRoute('task.read'));
+    }
     req.status = status;
     res.locals.static.profile = req.task.data.changedBy;
     next();


### PR DESCRIPTION
If no status can be determined from the session then redirect the success page back to the task screen. Otherwise errors are thrown later in the middleware pipeline.

Copies [the equivalent code in the confirm router](https://github.com/UKHomeOffice/asl-pages/blob/master/pages/task/read/routers/confirm.js#L12-L14).