### PR TITLE
Don't assume top-level session exists

### DIFF
--- a/pages/pil/procedures/index.js
+++ b/pages/pil/procedures/index.js
@@ -32,7 +32,8 @@ module.exports = settings => {
 
   app.post('/', (req, res, next) => {
     const procedures = get(req.session, `form[${req.model.id}].values`);
-    req.session.form[req.pil.id].values = Object.assign({}, req.session.form[req.pil.id].values, procedures);
+    const savedValues = get(req.session, `form[${req.pil.id}].values`);
+    req.session.form[req.pil.id].values = Object.assign({}, savedValues, procedures);
     delete req.session.form[req.pil.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update'));
   });


### PR DESCRIPTION
If a person takes a while completing the procedures part of a PIL application then they can end up losing the values from the top-level PIL application on the session. If that happens then don't throw, just save the current procedures and continue.