### PR TITLE
Improve error message when no task option selected

### DIFF
--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -49,7 +49,7 @@ module.exports = {
   },
   errors: {
     status: {
-      required: 'Please approve or reject this task',
+      required: 'Please select an option from the list',
       definedValues: 'Please select an option from the list'
     },
     comment: {


### PR DESCRIPTION
The old content doesn't make any sense for people who have options other than approve or reject.