### PR TITLE
Fix permissions check for import route

### DIFF
--- a/pages/project/routes.js
+++ b/pages/project/routes.js
@@ -9,7 +9,7 @@ const revoke = require('./revoke');
 const projectPermissions = task => (req, res, next) => {
   const params = {
     id: req.projectId,
-    licenceHolderId: req.project.licenceHolderId,
+    licenceHolderId: req.project && req.project.licenceHolderId,
     establishment: req.establishment.id
   };
   permissions(task, params)(req, res, next);


### PR DESCRIPTION
`req.project` doesn't exist for imports, so the checking of `req.project.licenceHolderId` fails with an error.