### PR TITLE
Throw a 404 error for malformed project id

### DIFF
--- a/pages/project/index.js
+++ b/pages/project/index.js
@@ -1,4 +1,6 @@
 const { Router } = require('express');
+const isUUID = require('uuid-validate');
+const { NotFoundError } = require('@asl/service/errors');
 const routes = require('./routes');
 
 module.exports = settings => {
@@ -7,6 +9,9 @@ module.exports = settings => {
   app.param('projectId', (req, res, next, projectId) => {
     if (projectId === 'create' || projectId === 'import') {
       return next('route');
+    }
+    if (!isUUID(projectId)) {
+      return next(new NotFoundError());
     }
     req.projectId = projectId;
     return req.api(`/establishment/${req.establishmentId}/projects/${projectId}`)


### PR DESCRIPTION
Currently this attempts to do a db lookup but fails because the id is not a UUID. Catch that case early and respond with a 404 instead of a 500.