### PR TITLE
Handle double posts to task updates

### DIFF
--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -9,7 +9,7 @@ module.exports = () => {
   app.use((req, res, next) => {
     req.model = { id: req.task.id };
     const status = get(req, `session.form[${req.task.id}].values.status`);
-    if (!status) {
+    if (!status || status === req.task.status) {
       return res.redirect(req.buildRoute('task.read'));
     }
     next();

--- a/pages/task/schema/confirm.js
+++ b/pages/task/schema/confirm.js
@@ -1,6 +1,7 @@
 module.exports = (task, chosenStatus) => {
   const commentRequired = stepId => {
-    return task.nextSteps.find(nextStep => nextStep.id === stepId).commentRequired;
+    const nextStep = task.nextSteps.find(nextStep => nextStep.id === stepId);
+    return nextStep && nextStep.commentRequired;
   };
 
   return {


### PR DESCRIPTION
If a task is being set to a status which it is already at then simply redirect back to the task page.

It seems like licensing officers are making multiple near-simultaneous requests, either through multiple rapid-fire clicks, or refreshing if there's latency. This eventually results in an error on the subsequent requests. Instead handle it gracefully and return them to their processed task.