### PR TITLE
PILs are still owned by the original establishment until transfer is approved

### DIFF
--- a/pages/pil/dashboard/index.js
+++ b/pages/pil/dashboard/index.js
@@ -98,7 +98,10 @@ module.exports = settings => {
       res.locals.static.skipTraining = get(req.session, [req.profileId, 'skipTraining'], null);
       res.locals.static.isAsru = req.user.profile.asruUser;
       res.locals.static.isLicensing = req.user.profile.asruLicensing;
-      res.locals.static.canTransferPil = req.pil.status === 'active' && req.user.profile.id === req.profile.id; // can only transfer own (active) pil
+
+      // can only transfer own pil if it's active and has no in-progress amendment
+      const hasOpenAmendment = req.pil.status === 'active' && get(req.model, 'openTasks[0].data.action') === 'grant';
+      res.locals.static.canTransferPil = req.pil.status === 'active' && req.user.profile.id === req.profile.id && !hasOpenAmendment;
 
       next();
     }

--- a/pages/task/read/middleware/update-data.js
+++ b/pages/task/read/middleware/update-data.js
@@ -26,6 +26,11 @@ module.exports = (req, res, next) => {
     });
   }
 
+  if (model === 'pil' && action === 'transfer') {
+    // use the owning establishment id not the receiving establishment id
+    params.establishmentId = get(req.task, 'data.data.establishment.from.id');
+  }
+
   if (model === 'project') {
     if (action === 'grant') {
       model = 'projectVersion';


### PR DESCRIPTION
PILs are only editable at the establishment that owns them, so send the user to the correct establishment.

This will mean that admins on the receiving side still won't be able to edit a PIL transfer in progress, but at least the applicant will be able to.