### PR TITLE
Bugfix - hydrate procedures and species

### DIFF
--- a/pages/pil/procedures/index.js
+++ b/pages/pil/procedures/index.js
@@ -12,7 +12,7 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     req.model = merge({ id: `${req.pilId}-procedures` },
-      pick(req.pil, 'procedures', 'notesCatD', 'notesCatF'),
+      pick(req.model, 'procedures', 'notesCatD', 'notesCatF'),
       buildModel(schema)
     );
     next();

--- a/pages/pil/species/index.js
+++ b/pages/pil/species/index.js
@@ -11,7 +11,7 @@ module.exports = () => {
 
   app.use((req, res, next) => {
     req.model = merge({ id: `${req.pilId}-species` },
-      pick(req.pil, 'species'),
+      pick(req.model, 'species'),
       buildModel(schema)
     );
     next();


### PR DESCRIPTION
* These were using req.pil as a base, which is not hydrated from task data on a task update.
* Use req.model instead which is updated correctly