### PR TITLE
Refactor requiresDeclaration definition

### DIFF
--- a/pages/establishment/update/routers/confirm.js
+++ b/pages/establishment/update/routers/confirm.js
@@ -31,15 +31,11 @@ module.exports = () => {
 
   app.post('/', updateDataFromTask(sendData));
 
-  app.use((req, res, next) => {
-    req.requiresDeclaration = !req.user.profile.asruUser;
-    next();
-  });
-
   app.use(form({
     model: 'establishment',
     configure(req, res, next) {
-      req.form.schema = req.requiresDeclaration ? declarationsSchema : {};
+      req.form.requiresDeclaration = !req.user.profile.asruUser;
+      req.form.schema = req.form.requiresDeclaration ? declarationsSchema : {};
       next();
     },
     saveValues: (req, res, next) => {
@@ -51,7 +47,7 @@ module.exports = () => {
       Object.assign(res.locals.static, {
         schema: Object.assign({}, schema, declarationsSchema),
         values: req.session.form[req.model.id].values,
-        requiresDeclaration: req.requiresDeclaration
+        requiresDeclaration: req.form.requiresDeclaration
       });
       next();
     },

--- a/pages/place/routers/confirm.js
+++ b/pages/place/routers/confirm.js
@@ -27,16 +27,12 @@ module.exports = settings => {
 
   app.post('/', updateDataFromTask(sendData));
 
-  app.use((req, res, next) => {
-    req.requiresDeclaration = !req.user.profile.asruUser;
-    next();
-  });
-
   app.use(
     form(Object.assign({
       model: 'place',
       configure(req, res, next) {
-        req.form.schema = req.requiresDeclaration ? declarationsSchema : {};
+        req.form.requiresDeclaration = !req.user.profile.asruUser;
+        req.form.schema = req.form.requiresDeclaration ? declarationsSchema : {};
         next();
       },
       saveValues: (req, res, next) => {
@@ -52,8 +48,8 @@ module.exports = settings => {
           .then(([establishment, nacwo]) => {
             Object.assign(res.locals.static, {
               establishment,
-              schema: Object.assign({}, schema, req.requiresDeclaration ? declarationsSchema : {}),
-              requiresDeclaration: req.requiresDeclaration,
+              schema: Object.assign({}, schema, req.form.requiresDeclaration ? declarationsSchema : {}),
+              requiresDeclaration: req.form.requiresDeclaration,
               values: {
                 ...req.session.form[req.model.id].values,
                 nacwo

--- a/pages/role/routers/confirm.js
+++ b/pages/role/routers/confirm.js
@@ -8,15 +8,11 @@ module.exports = settings => {
 
   app.post('/', updateDataFromTask(settings.sendData));
 
-  app.use((req, res, next) => {
-    req.requiresDeclaration = !req.user.profile.asruUser;
-    next();
-  });
-
   app.use('/', form({
     model: 'role-confirm',
     configure(req, res, next) {
-      req.form.schema = req.requiresDeclaration ? schema : {};
+      req.form.requiresDeclaration = !req.user.profile.asruUser;
+      req.form.schema = req.form.requiresDeclaration ? schema : {};
       next();
     },
     locals: (req, res, next) => {
@@ -26,7 +22,7 @@ module.exports = settings => {
         values: {
           ...req.session.form[req.model.id].values
         },
-        requiresDeclaration: req.requiresDeclaration
+        requiresDeclaration: req.form.requiresDeclaration
       });
       next();
     },


### PR DESCRIPTION
Move this into the `configure` method on the form so that all form-related operations are encapsulated into the context of the form router itself and not dependent on prior middleware.