### PR TITLE
Fix redirect in checkSession middleware on role.create

### DIFF
--- a/pages/role/apply/index.js
+++ b/pages/role/apply/index.js
@@ -56,7 +56,7 @@ module.exports = settings => {
   });
 
   app.use('/confirm', confirm({
-    type: 'create',
+    action: 'create',
     sendData
   }));
 


### PR DESCRIPTION
The redirect if a user's session expires currently tries to redirect to `role.undefined` because it uses the `action` param, which wasn't being passed.

I think the `type` is no longer relevant, or at least I can't see where it is used.