### PR TITLE
Don't overwrite pseudo form fields with empty session data

### DIFF
--- a/pages/common/routers/form.js
+++ b/pages/common/routers/form.js
@@ -7,6 +7,7 @@ const {
   map,
   size,
   get,
+  isEmpty,
   isUndefined,
   identity,
   pickBy,
@@ -176,7 +177,7 @@ module.exports = ({
 
   const _getValues = (req, res, next) => {
     req.form.values = cleanModel(pickValues(req.model, req.form.schema));
-    if (req.session.form[req.model.id].values) {
+    if (!isEmpty(req.session.form[req.model.id].values)) {
       Object.assign(req.form.values, cleanModel(pickValues(req.session.form[req.model.id].values, req.form.schema)));
     }
     return getValues(req, res, next);

--- a/test/unit/routers/form.spec.js
+++ b/test/unit/routers/form.spec.js
@@ -142,6 +142,61 @@ describe('Form Router', () => {
           done();
         });
       });
+
+      test('does not extend virtual props based on session value if session is empty', done => {
+        const schema = {
+          props: {
+            getValue: model => ['prop1', 'prop2'].filter(p => model[p])
+          }
+        };
+        req.model = {
+          prop1: true,
+          prop2: false
+        };
+        const expected = {
+          prop1: true,
+          prop2: false,
+          props: ['prop1']
+        };
+        form({ schema })(req, res, () => {
+          expect(req.form.values).toEqual(expected);
+          done();
+        });
+      });
+
+      test('extends virtual props based on session value if session is populated', done => {
+        const schema = {
+          props: {
+            getValue: model => ['prop1', 'prop2'].filter(p => model[p])
+          }
+        };
+        req.model = {
+          id: 'test',
+          prop1: true,
+          prop2: false
+        };
+        req.session = {
+          form: {
+            test: {
+              values: {
+                prop1: true,
+                prop2: true
+              }
+            }
+          }
+        };
+        const expected = {
+          id: 'test',
+          prop1: true,
+          prop2: true,
+          props: ['prop1', 'prop2']
+        };
+        form({ schema })(req, res, () => {
+          expect(req.form.values).toEqual(expected);
+          done();
+        });
+      });
+
     });
 
     describe('_getValidationErrors', () => {


### PR DESCRIPTION
The `getValue` functions are being invoked for "pseudo" form fields even when there is no session data present because the session is initialised with a value of `{}` which is always truthy.

Instead check that the session is non-empty before extending the model values with any session values.