### PR TITLE
Fix session check for establishment details confirm

### DIFF
--- a/pages/establishment/update/routers/confirm.js
+++ b/pages/establishment/update/routers/confirm.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { pick, merge } = require('lodash');
+const { get, pick, merge, isEmpty } = require('lodash');
 const form = require('../../../common/routers/form');
 const schema = require('../schema');
 const { updateDataFromTask, redirectToTaskIfOpen } = require('../../../common/middleware');
@@ -32,7 +32,8 @@ module.exports = () => {
   app.use(form({
     requiresDeclaration: req => !req.user.profile.asruUser,
     checkSession: (req, res, next) => {
-      if (req.session.form && req.session.form[req.model.id]) {
+      const values = get(req.session, `form.${req.model.id}.values`);
+      if (!isEmpty(values)) {
         return next();
       }
       return res.redirect(req.buildRoute('establishment.update'));


### PR DESCRIPTION
The establishment details endpoint mounts a form router, which means that if the details page has been recently hit then some basic data is stored on the session at the path being checked here.

This means that the session check middleware finds false negatives in a number of cases that result in an error being thrown.

Check that specifically the values have been set to the session and are non-empty rather than simply the existence of a top-level object to better ensure that the confirmation page is renderable.