### PR TITLE
Delete correct values from form session on certificate post

### DIFF
--- a/pages/pil/training/routers/certificate.js
+++ b/pages/pil/training/routers/certificate.js
@@ -43,7 +43,7 @@ module.exports = settings => {
   }));
 
   app.post('/', (req, res, next) => {
-    delete req.session.form[req.pil.id].validationErrors;
+    delete req.session.form[req.model.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update.training.modules'));
   });
 


### PR DESCRIPTION
The validation errors should be cleared from the certificate form (i.e. `req.model/id`) and not the top-level PIL.