### PR TITLE
Bugfix - pass est details to word renderer

### DIFF
--- a/pages/project-version/docx/index.js
+++ b/pages/project-version/docx/index.js
@@ -40,7 +40,12 @@ module.exports = () => {
     const values = req.version.data || {};
     const sections = Object.values(schema[req.project.schemaVersion]());
 
-    renderer(req.project, sections, values, updateImageDimensions)
+    const application = {
+      ...req.project,
+      establishment: req.establishment
+    };
+
+    renderer(application, sections, values, updateImageDimensions)
       .then(pack)
       .then(buffer => {
         res.attachment(`${values.title || 'Untitled project'}.docx`);


### PR DESCRIPTION
* `application` was intended to be store.application, not req.project - however the docx renderer has been amended to consume the latter.
* Added establishment to be used in renderer