### PR TITLE
Add review dates to PIL pages

### DIFF
--- a/pages/pil/read/content/index.js
+++ b/pages/pil/read/content/index.js
@@ -9,6 +9,7 @@ module.exports = merge({}, baseContent, {
     issueDate: { label: 'Issue date' },
     updatedAt: { label: 'Last amended' },
     revocationDate: { label: 'Revocation date' },
+    reviewDate: { label: 'Next review due' },
     species: { label: 'Animal types' },
     conditions: { label: 'Conditions' },
     procedures: { label: 'Procedures' }

--- a/pages/pil/read/schema/index.js
+++ b/pages/pil/read/schema/index.js
@@ -2,6 +2,8 @@ module.exports = {
   licenceNumber: { show: true },
   issueDate: { show: true },
   updatedAt: { show: true },
+  reviewDate: { show: true },
+  revocationDate: { show: true },
   species: { show: true },
   procedures: { show: true },
   conditions: { show: true }

--- a/pages/pil/read/views/index.jsx
+++ b/pages/pil/read/views/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { dateFormat } from '../../../../constants';
 import { formatDate } from '../../../../lib/utils';
 import differenceInCalendarDays from 'date-fns/difference_in_calendar_days';
+import omit from 'lodash/omit';
 import schema from '../schema';
 import {
   Link,
@@ -23,6 +24,8 @@ const PIL = ({
   correctEstablishment,
   currentPath
 }) => {
+  const pilSchema = pil.status === 'revoked' ? omit(schema, 'reviewDate', 'updatedAt') : omit(schema, 'revocationDate');
+
   const canUpdateConditions = allowedActions.includes('pil.updateConditions') && pil.status === 'active';
   const backToProfile = <Link page="profile.read" label={<Snippet>action.backToProfile</Snippet>} />;
 
@@ -37,6 +40,9 @@ const PIL = ({
     },
     revocationDate: {
       format: revocationDate => formatDate(revocationDate, dateFormat.medium)
+    },
+    reviewDate: {
+      format: reviewDate => formatDate(reviewDate, dateFormat.medium)
     },
     species: {
       format: pilSpecies => {
@@ -111,7 +117,7 @@ const PIL = ({
         basename={currentPath}
       />
 
-      <ModelSummary model={pil} formatters={formatters} schema={schema} formatNullValue={true} />
+      <ModelSummary model={pil} formatters={formatters} schema={pilSchema} formatNullValue={true} />
 
       {
         canUpdate && (


### PR DESCRIPTION
Hide the same field on revoked PILs because it wouldn't make any sense to display it.