### PR TITLE
Surface error status on PDF generator errors

### DIFF
--- a/pages/establishment/pdf/index.jsx
+++ b/pages/establishment/pdf/index.jsx
@@ -63,7 +63,7 @@ module.exports = settings => {
               res.attachment(`${establishment.licenceNumber}.pdf`);
               response.body.pipe(res);
             } else {
-              throw new Error('Error generating PDF');
+              throw new Error(`Error generating PDF - generator responded ${response.status}`);
             }
           })
           .catch(next);

--- a/pages/pil/pdf/index.jsx
+++ b/pages/pil/pdf/index.jsx
@@ -47,7 +47,7 @@ module.exports = settings => {
           res.attachment(`${pil.licenceNumber}.pdf`);
           response.body.pipe(res);
         } else {
-          throw new Error('Error generating PDF');
+          throw new Error(`Error generating PDF - generator responded ${response.status}`);
         }
       })
       .catch(next);

--- a/pages/project-version/pdf/index.jsx
+++ b/pages/project-version/pdf/index.jsx
@@ -57,7 +57,7 @@ module.exports = settings => {
           res.attachment(`${req.project.title}.pdf`);
           response.body.pipe(res);
         } else {
-          throw new Error('Error generating PDF');
+          throw new Error(`Error generating PDF - generator responded ${response.status}`);
         }
       })
       .catch(next);


### PR DESCRIPTION
Continue to throw 500 errors on the client, as _all_ PDF should render correctly, but include downstream error status in message to allow easier debugging.