### PR TITLE
Show value from API for PEL fee

### DIFF
--- a/pages/establishment/licence-fees/overview/views/index.jsx
+++ b/pages/establishment/licence-fees/overview/views/index.jsx
@@ -11,7 +11,7 @@ export default function Overview() {
       rows: [
         {
           title: 'fees.overview.establishment.fee',
-          value: fees.fees.pel,
+          value: fees.establishment,
           currency: true
         }
       ]


### PR DESCRIPTION
This could be the configured fee or it could be zero depending on whether or not the PEL was active during the billing period.