### PR TITLE
Fix error handler for billing redirect

### DIFF
--- a/pages/establishment/licence-fees/index.js
+++ b/pages/establishment/licence-fees/index.js
@@ -16,7 +16,7 @@ module.exports = settings => {
         const year = response.json.meta.year;
         res.redirect(req.buildRoute('establishment.fees.overview', { year }));
       })
-      .catch(() => next);
+      .catch(next);
   });
 
   app.use('/:year', (req, res, next) => {


### PR DESCRIPTION
It wasn't actually calling the `next` function before so would just hang on an error.