### PR TITLE
Support dynamic and placeholder dates in date validation functions

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -57,9 +57,21 @@ const validators = {
     return isNull(date) || moment(date, 'YYYY-MM-DD').isValid();
   },
   dateIsBefore(date, isBefore) {
+    if (typeof isBefore === 'function') {
+      isBefore = isBefore();
+    }
+    if (isBefore === 'now') {
+      isBefore = moment();
+    }
     return isNull(date) || moment(date, 'YYYY-MM-DD').isBefore(isBefore);
   },
   dateIsAfter(date, isAfter) {
+    if (typeof isAfter === 'function') {
+      isAfter = isAfter();
+    }
+    if (isAfter === 'now') {
+      isAfter = moment();
+    }
     return isNull(date) || moment(date, 'YYYY-MM-DD').isAfter(isAfter);
   },
   // file validation

--- a/pages/pil/training/schema/certificate.js
+++ b/pages/pil/training/schema/certificate.js
@@ -1,5 +1,4 @@
 const { accreditingBodies } = require('@asl/constants');
-const moment = require('moment');
 
 module.exports = {
   certificateNumber: {
@@ -37,7 +36,7 @@ module.exports = {
     validate: [
       'required',
       'validDate',
-      { dateIsBefore: moment() }
+      { dateIsBefore: 'now' }
     ]
   }
 };

--- a/pages/user/update/schema/index.js
+++ b/pages/user/update/schema/index.js
@@ -1,5 +1,3 @@
-const moment = require('moment');
-
 module.exports = {
   firstName: {
     inputType: 'inputText',
@@ -18,7 +16,7 @@ module.exports = {
     validate: [
       'required',
       'validDate',
-      { dateIsBefore: moment() }
+      { dateIsBefore: 'now' }
     ]
   },
   telephone: {

--- a/test/unit/validation/validators.spec.js
+++ b/test/unit/validation/validators.spec.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+import sinon from 'sinon';
 import validators from '../../../lib/validation/validators';
 
 const doTest = (value, params, type, expected) => {
@@ -150,4 +152,80 @@ describe('validation', () => {
       values.forEach(value => doTest(value, true, 'required', false));
     });
   });
+
+  describe('dates', () => {
+
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        now: moment('2020-01-20').valueOf()
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    describe('isDateBefore/isDateAfter', () => {
+
+      describe('can use a hardcoded date as a comparator', () => {
+        const before = [
+          '2019-01-01',
+          '2018-12-31'
+        ];
+        const after = [
+          '2019-01-03',
+          '2020-01-01'
+        ];
+        describe('before', () => {
+          before.forEach(value => doTest(value, '2019-01-02', 'dateIsBefore', true));
+          before.forEach(value => doTest(value, '2019-01-02', 'dateIsAfter', false));
+        });
+        describe('after', () => {
+          after.forEach(value => doTest(value, '2019-01-02', 'dateIsBefore', false));
+          after.forEach(value => doTest(value, '2019-01-02', 'dateIsAfter', true));
+        });
+      });
+
+      describe('can use a dynamic date as a comparator', () => {
+        // current date is mocked to 2010-01-20
+        const before = [
+          '2020-01-14'
+        ];
+        const after = [
+          '2020-01-16'
+        ];
+        describe('before', () => {
+          before.forEach(value => doTest(value, () => moment().subtract(5, 'days'), 'dateIsBefore', true));
+          before.forEach(value => doTest(value, () => moment().subtract(5, 'days'), 'dateIsAfter', false));
+        });
+        describe('after', () => {
+          after.forEach(value => doTest(value, () => moment().subtract(5, 'days'), 'dateIsBefore', false));
+          after.forEach(value => doTest(value, () => moment().subtract(5, 'days'), 'dateIsAfter', true));
+        });
+      });
+
+      describe('can use "now" as a shortcut to the current date as a comparator', () => {
+        // current date is mocked to 2010-01-20
+        const before = [
+          '2020-01-19'
+        ];
+        const after = [
+          '2020-01-21'
+        ];
+        describe('before', () => {
+          before.forEach(value => doTest(value, 'now', 'dateIsBefore', true));
+          before.forEach(value => doTest(value, 'now', 'dateIsAfter', false));
+        });
+        describe('after', () => {
+          after.forEach(value => doTest(value, 'now', 'dateIsBefore', false));
+          after.forEach(value => doTest(value, 'now', 'dateIsAfter', true));
+        });
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
Defining the date in the schema only allows for a fixed date to be used for validation, and not one that is relative to the current time. Add support for comparison date functions in validators so that dates relative to the current date can be used.

Additionally add support for a `'now'` shortcut to the current date.