### PR TITLE
Fix links to profiles in tasks with no establishments

### DIFF
--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -13,6 +13,14 @@ const getStatusBadge = status => {
   return <span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span>;
 };
 
+const getProfileLink = ({ id, name, establishmentId }) => {
+  if (establishmentId) {
+    return <Link page="profile.read" profileId={id} establishmentId={establishmentId} label={name} />;
+  } else {
+    return <Link page="globalProfile" profileId={id} label={name} />;
+  }
+};
+
 const getAuthor = ({ changedBy, event: { status } }, task) => {
   const name = `${changedBy.firstName} ${changedBy.lastName}`;
   const action = <Snippet fallback={`status.${status}.log`}>{`status.${status}.log.${task.type}`}</Snippet>;
@@ -22,7 +30,7 @@ const getAuthor = ({ changedBy, event: { status } }, task) => {
       {
         changedBy.asruUser
           ? name
-          : <Link page="profile.read" profileId={changedBy.id} establishmentId={task.data.establishmentId} label={name} />
+          : getProfileLink({ id: changedBy.id, name, establishmentId: task.data.establishmentId })
       }
     </p>
   );


### PR DESCRIPTION
If a task has no establishment id associated with it then make any links within the activity log go to a global profile rather than an estabishment scoped one.