### PR TITLE
Update content for PPL deadline expiry in task lists

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -7,6 +7,12 @@ module.exports = {
   fields,
   tasks,
   title: 'Task list',
+  countdown: {
+    singular: '1 {{unit}} left',
+    plural: '{{diff}} {{unit}}s left',
+    expired: 'Deadline passed',
+    expiresToday: 'Deadline today'
+  },
   tabs: {
     outstanding: 'Outstanding',
     inProgress: 'In progress',


### PR DESCRIPTION
Override the default content used for project expiry with specific content for PPL review deadlines.