### PR TITLE
Display the what next section if there is a discard option

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -342,7 +342,10 @@ details {
   &.asru-discard-task {
     margin-top: $govuk-gutter-half;
     padding-top: $govuk-gutter;
-    border-top: 2px solid govuk-colour('grey-1');
+
+    &.border {
+      border-top: 2px solid govuk-colour('grey-1');
+    }
   }
 
   summary {

--- a/pages/task/read/views/models/index.jsx
+++ b/pages/task/read/views/models/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
+import classnames from 'classnames';
 import {
   StickyNavPage,
   StickyNavAnchor,
@@ -28,9 +29,9 @@ const models = {
 
 const selector = ({ static: { schema, values } }) => ({ schema, values });
 
-const AsruDiscard = ({ task }) => {
+const AsruDiscard = ({ task, showBorder }) => {
   return (
-    <details className="asru-discard-task">
+    <details className={classnames('asru-discard-task', { border: showBorder })}>
       <summary><Snippet>asruDiscardTask.summary</Snippet></summary>
       <Inset>
         <p><Snippet>asruDiscardTask.details</Snippet></p>
@@ -49,6 +50,9 @@ export default function Model({ task, formFields }) {
   const { schema, values } = useSelector(selector, shallowEqual);
   const Model = models[task.data.model];
   const hasComments = task.data.meta && task.data.meta.comments;
+
+  const hasNextSteps = task.nextSteps.length > 0;
+  const hasTaskOptions = schema.status.options.length > 0;
   const canBeDiscardedByAsru = task.nextSteps.find(step => step.id === 'discarded-by-asru');
 
   return (
@@ -70,13 +74,13 @@ export default function Model({ task, formFields }) {
         )
       }
       {
-        schema.status.options.length > 0 &&
+        hasNextSteps &&
           <StickyNavAnchor id="status">
             <h2><Snippet>sticky-nav.status</Snippet></h2>
             <p><Snippet>make-decision.hint</Snippet></p>
-            { formFields }
+            { hasTaskOptions && formFields }
             {
-              canBeDiscardedByAsru && <AsruDiscard task={task} />
+              canBeDiscardedByAsru && <AsruDiscard task={task} showBorder={hasTaskOptions} />
             }
           </StickyNavAnchor>
       }


### PR DESCRIPTION
If the user was just ASRU admin and didn't have LO or Inspector roles, the only next step available was discard, which was is filtered from the schema options. This meant the "What do you want to do?" section never rendered.

This now shows the "What do you want to do?" section even if the only action available is discard.

With multiple options:
![multiple-opts](https://user-images.githubusercontent.com/1880478/73288577-27465300-41f3-11ea-8101-6347f6556b4b.png)

With only discard option:
![only-discard](https://user-images.githubusercontent.com/1880478/73288578-27dee980-41f3-11ea-9d9a-767217c2a79f.png)


