### PR TITLE
Remove grey background from expanding panels inside panel lists

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -133,6 +133,13 @@ p.subtitle {
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
+
+  .expanding-panel {
+    border: none;
+    header {
+      background: none;
+    }
+  }
 }
 
 p.control-panel {


### PR DESCRIPTION
As seen on the external home page and global profile pages. These random borders and backgrounds look super nasty and should be removed.

Before:

<img width="905" alt="Screenshot 2020-01-29 at 12 27 39" src="https://user-images.githubusercontent.com/117398/73356773-f584c900-4292-11ea-9048-95f4a2c9e71e.png">

After:

<img width="901" alt="Screenshot 2020-01-29 at 12 28 03" src="https://user-images.githubusercontent.com/117398/73356799-07ff0280-4293-11ea-9cc0-5881f4287cfc.png">
