### PR TITLE
Make spacing on establishment dashboard roles consistent

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -164,7 +164,8 @@ p.control-panel {
 }
 
 p.inspector,
-p.spoc {
+p.spoc,
+p.holc {
   margin: 0;
 }
 


### PR DESCRIPTION
HOLCs have a load of margin but SPoCs and inspectors are compact. Make them all compact.