### PR TITLE
Remove limit limit on datatables

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -7,8 +7,7 @@ const { cleanModel, removeQueryParams } = require('../../../lib/utils');
 const defaultMiddleware = (req, res, next) => next();
 
 const getLimit = (rows = 10) => {
-  rows = parseInt(rows, 10);
-  return rows < 1000 ? rows : 1000;
+  return parseInt(rows, 10);
 };
 
 const buildQuery = (req, schema) => {


### PR DESCRIPTION
Stop capping the limit at 100 rows because there's a legit need for arbitrarily large tables.

We could add an arbitrarily larger limit limit but Y THO?