### PR TITLE
Fix the "reason for amendment" question in tasks

### DIFF
--- a/pages/project-version/update/submit/content/index.js
+++ b/pages/project-version/update/submit/content/index.js
@@ -28,7 +28,7 @@ module.exports = {
       label: 'Comments',
       hint: 'Comments can be seen by inspectors and Home Office team members. They will be added to the \'Latest activity\' log of this task.'
     },
-    reason: {
+    comments: {
       label: 'Why are you making this amendment?'
     }
   },
@@ -54,7 +54,7 @@ module.exports = {
     ready: {
       required: 'Select an option'
     },
-    reason: {
+    comments: {
       required: 'Please provide a reason'
     }
   },

--- a/pages/project-version/update/submit/index.js
+++ b/pages/project-version/update/submit/index.js
@@ -25,7 +25,7 @@ module.exports = settings => {
         'authority-endorsement-date',
         'awerb-review-date',
         'awerb-no-review-reason',
-        'reason',
+        'comments',
         'comment'
       ]));
     }

--- a/pages/project-version/update/submit/schema/index.js
+++ b/pages/project-version/update/submit/schema/index.js
@@ -53,7 +53,7 @@ const getSchema = (type, isAsru) => {
       ],
       validate: ['required']
     },
-    reason: {
+    comments: {
       inputType: 'textarea',
       validate: ['required']
     },
@@ -63,7 +63,7 @@ const getSchema = (type, isAsru) => {
   };
 
   if (isAsru) {
-    return pick(schema, 'reason', 'comment');
+    return pick(schema, 'comments', 'comment');
   }
 
   if (type === 'amendment') {
@@ -86,7 +86,7 @@ const getSchema = (type, isAsru) => {
     return omit(schema, 'ready');
   }
 
-  return omit(schema, 'reason');
+  return omit(schema, 'comments');
 };
 
 module.exports = getSchema;

--- a/pages/task/index.js
+++ b/pages/task/index.js
@@ -1,15 +1,6 @@
 const { Router } = require('express');
 const routes = require('./routes');
 
-const handlePplAmendmentReason = task => {
-  // previously we used task.data.meta.comments for the amendment reason, now it has it's own property
-  if (task.data.model === 'project' && task.type === 'amendment' && !task.data.meta.reason && task.data.meta.comments) {
-    task.data.meta.reason = task.data.meta.comments;
-    delete task.data.meta.comments;
-  }
-  return task;
-};
-
 module.exports = settings => {
   const app = Router();
 
@@ -17,8 +8,7 @@ module.exports = settings => {
     return req.api(`/tasks/${taskId}`)
       .then(response => {
         req.taskId = taskId;
-        const task = response.json.data;
-        req.task = handlePplAmendmentReason(task);
+        req.task = response.json.data;
       })
       .then(() => next())
       .catch(next);

--- a/pages/task/index.js
+++ b/pages/task/index.js
@@ -1,9 +1,9 @@
 const { Router } = require('express');
 const routes = require('./routes');
 
-const handleAmendmentReason = task => {
+const handlePplAmendmentReason = task => {
   // previously we used task.data.meta.comments for the amendment reason, now it has it's own property
-  if (task.type === 'amendment' && !task.data.meta.reason && task.data.meta.comments) {
+  if (task.data.model === 'project' && task.type === 'amendment' && !task.data.meta.reason && task.data.meta.comments) {
     task.data.meta.reason = task.data.meta.comments;
     delete task.data.meta.comments;
   }
@@ -18,7 +18,7 @@ module.exports = settings => {
       .then(response => {
         req.taskId = taskId;
         const task = response.json.data;
-        req.task = handleAmendmentReason(task);
+        req.task = handlePplAmendmentReason(task);
       })
       .then(() => next())
       .catch(next);

--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -18,7 +18,7 @@ module.exports = {
   'sticky-nav': {
     activity: 'Latest activity',
     establishment: 'Establishment details',
-    reason: 'Reason for amendment',
+    comments: 'Reason for amendment',
     revocation: 'Reason for revocation',
     status: 'What do you want to do?',
     conditions: 'Additional conditions'

--- a/pages/task/read/views/models/index.jsx
+++ b/pages/task/read/views/models/index.jsx
@@ -49,7 +49,7 @@ const AsruDiscard = ({ task, showBorder }) => {
 export default function Model({ task, formFields, allowSubmit }) {
   const { schema, values } = useSelector(selector, shallowEqual);
   const Model = models[task.data.model];
-  const hasReason = task.data.meta && task.data.meta.reason;
+  const hasComments = task.data.meta && task.data.meta.comments;
 
   const hasNextSteps = task.nextSteps.length > 0;
   const hasTaskOptions = schema.status.options.length > 0;
@@ -64,11 +64,11 @@ export default function Model({ task, formFields, allowSubmit }) {
         Model({ task, schema, values, allowSubmit })
       }
       {
-        hasReason && (
-          <StickyNavAnchor id={task.data.action === 'revoke' ? 'revocation' : 'reason'}>
+        hasComments && (
+          <StickyNavAnchor id={task.data.action === 'revoke' ? 'revocation' : 'comments'}>
             <Field
-              title={<Snippet>{`sticky-nav.${task.data.action === 'revoke' ? 'revocation' : 'reason'}`}</Snippet>}
-              content={task.data.meta.reason}
+              title={<Snippet>{`sticky-nav.${task.data.action === 'revoke' ? 'revocation' : 'comments'}`}</Snippet>}
+              content={task.data.meta.comments}
             />
           </StickyNavAnchor>
         )


### PR DESCRIPTION
I attempted to rename "comments" to "reason" for clarity, but it affects more than just projects. We should revisit with a view to renaming it for all licence types, but for now lets get it working with the existing field name.