### PR TITLE
Fix comparison of null fields

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -28,7 +28,7 @@ const getValue = ({ row, schema, key }) => {
 const hasChanged = (newValue, oldValue, { accessor } = {}) => {
   oldValue = get(oldValue, accessor, oldValue);
   newValue = get(newValue, accessor, newValue);
-  if (oldValue === undefined) {
+  if (oldValue === undefined || oldValue === null) {
     return !!newValue;
   }
   if (Array.isArray(newValue)) {


### PR DESCRIPTION
If the saved result for a model is null, then `hasChanged` returns true for empty strings. Make it so that only a change to a truthy value counts as a change if the underlying field has a null value.

Specifically it's currently possible to submit a place amendment with no changes if the restrictions are null, because `isEqual('', null) === true`