### PR TITLE
Allow adding roles from other establishments

### DIFF
--- a/pages/role/apply/index.js
+++ b/pages/role/apply/index.js
@@ -38,7 +38,9 @@ module.exports = settings => {
 
   app.use('/', form({
     configure: (req, res, next) => {
-      const roles = req.profile.roles.map(role => role.type);
+      const roles = req.profile.roles
+        .filter(role => role.establishmentId === req.establishmentId)
+        .map(role => role.type);
       req.form.schema = {
         ...getSchema(roles),
         rcvsNumber: {}

--- a/pages/role/remove/index.js
+++ b/pages/role/remove/index.js
@@ -1,6 +1,6 @@
 const { page } = require('@asl/service/ui');
 const form = require('../../common/routers/form');
-const schema = require('./schema');
+const getSchema = require('./schema');
 const confirm = require('../routers/confirm');
 const success = require('../routers/success');
 
@@ -32,7 +32,7 @@ module.exports = settings => {
         .filter(role => role.establishmentId === req.establishmentId)
         .map(role => role.type);
       req.form.schema = {
-        ...schema(roles, 'remove')
+        ...getSchema(roles)
       };
       next();
     },

--- a/pages/role/remove/index.js
+++ b/pages/role/remove/index.js
@@ -28,8 +28,11 @@ module.exports = settings => {
 
   app.use('/', form({
     configure: (req, res, next) => {
+      const roles = req.profile.roles
+        .filter(role => role.establishmentId === req.establishmentId)
+        .map(role => role.type);
       req.form.schema = {
-        ...schema(req.profile.roles, 'remove')
+        ...schema(roles, 'remove')
       };
       next();
     },

--- a/pages/role/remove/schema/index.js
+++ b/pages/role/remove/schema/index.js
@@ -3,8 +3,8 @@ const namedRoles = require('../../content/named-roles');
 module.exports = roles => {
   const options = roles.map(role => {
     return {
-      value: role.type,
-      label: namedRoles[role.type]
+      value: role,
+      label: namedRoles[role]
     };
   });
 
@@ -14,7 +14,7 @@ module.exports = roles => {
       validate: [
         'required',
         {
-          definedValues: roles.map(r => r.type)
+          definedValues: roles
         }
       ],
       options,


### PR DESCRIPTION
Currently the add role screen omits roles if the user already holds them, irrespective of what establishment they hold them at.

Filter the list of excluded roles to only those that are held at the current establishment.