### PR TITLE
Check roles and projects have correct establishment when removing permissions

### DIFF
--- a/pages/profile/permission/index.js
+++ b/pages/profile/permission/index.js
@@ -20,10 +20,10 @@ module.exports = settings => {
   }));
 
   app.use('/', (req, res, next) => {
-    const hasRoles = !!(req.profile.roles && req.profile.roles.length);
-    const hasPil = !!(req.profile.pil && req.profile.pil.status === 'active' && req.profile.pil.establishmentId === req.establishmentId);
-    const hasProjects = !!(req.profile.projects && req.profile.projects.length && some(req.profile.projects, project => project.status === 'active'));
-    res.locals.static.isNamed = hasRoles || hasPil || hasProjects;
+    const hasRoles = some(req.profile.roles, role => role.establishmentId === req.establishmentId);
+    const hasPil = req.profile.pil && req.profile.pil.status === 'active' && req.profile.pil.establishmentId === req.establishmentId;
+    const hasProjects = some(req.profile.projects, project => project.status === 'active' && project.establishmentId === req.establishmentId);
+    res.locals.static.isNamed = !!hasRoles || !!hasPil || !!hasProjects;
     next();
   });
 


### PR DESCRIPTION
If a user has roles and projects at any establishments then they can't be removed from other establishments.

Make sure that roles and projects have establishment ids that match the current estasblishment when removing permissions.