### PR TITLE
Redirect edit URL to readonly view for non-draft PPL versions

### DIFF
--- a/pages/project-version/update/index.js
+++ b/pages/project-version/update/index.js
@@ -9,6 +9,14 @@ module.exports = () => {
 
   app.use(getVersion());
 
+  app.use((req, res, next) => {
+    //move users away from edit route if not viewing a draft
+    if (req.version.status !== 'draft') {
+      return res.redirect(req.buildRoute('projectVersion.read'));
+    }
+    next();
+  });
+
   app.use(getComments());
 
   app.use('/submit', submit());

--- a/pages/project-version/update/js/index.js
+++ b/pages/project-version/update/js/index.js
@@ -28,5 +28,6 @@ start({
     schemaVersion: state.model.project.schemaVersion,
     newApplication: state.static.newApplication,
     previousProtocols: state.static.previousProtocols
-  }
+  },
+  static: { urls: state.static.urls }
 });


### PR DESCRIPTION
If a user ends up on `/edit` for a version that is not a draft then redirect them away to the readonly URL.

Also add `urls` to initial state for update view so that links work correctly where used.