### PR TITLE
Move redirect to below success page router

### DIFF
--- a/pages/project-version/update/index.js
+++ b/pages/project-version/update/index.js
@@ -9,6 +9,11 @@ module.exports = () => {
 
   app.use(getVersion());
 
+  app.use(getComments());
+
+  app.use('/submit', submit());
+  app.use('/success', success());
+
   app.use((req, res, next) => {
     //move users away from edit route if not viewing a draft
     if (req.version.status !== 'draft') {
@@ -16,11 +21,6 @@ module.exports = () => {
     }
     next();
   });
-
-  app.use(getComments());
-
-  app.use('/submit', submit());
-  app.use('/success', success());
 
   // we always want to serve the same template and
   // scripts for any sub-routes under /edit


### PR DESCRIPTION
If we redirect non-draft versions before the success page router then we never render success pages on submission.

Instead move the redirect down so success pages can render correctly.