### PR TITLE
Bugfix - use forked id from data

### DIFF
--- a/pages/project/read/index.js
+++ b/pages/project/read/index.js
@@ -53,8 +53,10 @@ module.exports = settings => {
 
   app.post('/', (req, res, next) => {
     req.api(`/establishment/${req.establishmentId}/project/${req.projectId}/fork`, { method: 'POST' })
-      .then(({ json: { data: task } }) => {
-        req.versionId = get(task, 'data.data.versionId');
+      .then(response => {
+        // bc - we previously used the modelId, which is now the project, not the version.
+        const modelId = get(response, 'json.data.data.id');
+        req.versionId = get(response, 'json.data.data.data.versionId', modelId);
         res.redirect(req.buildRoute('projectVersion.update'));
       })
       .catch(next);

--- a/pages/project/read/index.js
+++ b/pages/project/read/index.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash');
 const { page } = require('@asl/service/ui');
 
 module.exports = settings => {
@@ -52,8 +53,8 @@ module.exports = settings => {
 
   app.post('/', (req, res, next) => {
     req.api(`/establishment/${req.establishmentId}/project/${req.projectId}/fork`, { method: 'POST' })
-      .then(({ json: { data } }) => {
-        req.versionId = data.data.id;
+      .then(({ json: { data: task } }) => {
+        req.versionId = get(task, 'data.data.versionId');
         res.redirect(req.buildRoute('projectVersion.update'));
       })
       .catch(next);


### PR DESCRIPTION
* we were previously updating the top level id in the task when a project was forked - this should have been the project id, which resulted in broken task screens in some situations.