### PR TITLE
External users should not see in progress stub changes

### DIFF
--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -39,8 +39,7 @@ function CurrentVersion({ model }) {
     ? 'projectVersion.update'
     : 'projectVersion';
 
-  // always link to the latest version if a stub
-  const versionId = model.granted && !model.isLegacyStub
+  const versionId = model.granted
     ? model.granted.id
     : model.versions[0].id;
 


### PR DESCRIPTION
When an ASRU LO starts adding additional data to a stub, it creates a new draft version.

This version should not be visible to non-LOs (internal or external) until it has been converted into a standard licence.