### PR TITLE
Don't hide project landing page actions for stubs

### DIFF
--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -279,8 +279,10 @@ function Actions({ model }) {
   // project can be edited if it is active or a draft.
   const isEditable = model.status === 'inactive' || model.status === 'active';
 
-  if ((!canUpdate && !canRevoke) || !isEditable) {
-    return null;
+  if (!model.isLegacyStub) {
+    if ((!canUpdate && !canRevoke) || !isEditable) {
+      return null;
+    }
   }
 
   return (


### PR DESCRIPTION
If a stub is expired, we should still be able to add more details or discard it.