### PR TITLE
Use granted version for landing page status banner if it exists

### DIFF
--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -347,10 +347,11 @@ export default function ProjectLandingPage() {
 
   const isRevoked = model.status === 'revoked';
   const isEditable = model.status === 'active' || model.status === 'inactive';
+  const grantedVersion = model.versions.find(v => v.status === 'granted');
 
   return (
     <Fragment>
-      <ProjectStatusBanner model={model} version={model.versions[0]} />
+      <ProjectStatusBanner model={model} version={grantedVersion || model.versions[0]} />
 
       <Header
         subtitle={establishment.name}


### PR DESCRIPTION
By using the first version always then we end up showing a draft banner whenever a draft exists.

Instead use the granted version if one exists.