### PR TITLE
Handle missing PIL session when saving species and procedure data

### DIFF
--- a/pages/pil/procedures/index.js
+++ b/pages/pil/procedures/index.js
@@ -1,4 +1,4 @@
-const { get, pick, merge } = require('lodash');
+const { get, set, pick, merge } = require('lodash');
 const { page } = require('@asl/service/ui');
 const form = require('../../common/routers/form');
 const schema = require('./schema');
@@ -33,7 +33,7 @@ module.exports = settings => {
   app.post('/', (req, res, next) => {
     const procedures = get(req.session, `form[${req.model.id}].values`);
     const savedValues = get(req.session, `form[${req.pil.id}].values`);
-    req.session.form[req.pil.id].values = Object.assign({}, savedValues, procedures);
+    set(req.session, `form[${req.pil.id}].values`, Object.assign({}, savedValues, procedures));
     delete req.session.form[req.model.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update'));
   });

--- a/pages/pil/species/index.js
+++ b/pages/pil/species/index.js
@@ -1,4 +1,4 @@
-const { get, merge, pick } = require('lodash');
+const { get, set, merge, pick } = require('lodash');
 const { page } = require('@asl/service/ui');
 const { form } = require('../../common/routers');
 const schema = require('./schema');
@@ -22,7 +22,7 @@ module.exports = () => {
   app.post('/', (req, res, next) => {
     const species = get(req.session, `form[${req.model.id}].values`);
     const savedValues = get(req.session, `form[${req.pil.id}].values`);
-    req.session.form[req.pil.id].values = Object.assign({}, savedValues, species);
+    set(req.session, `form[${req.pil.id}].values`, Object.assign({}, savedValues, species));
     delete req.session.form[req.model.id].validationErrors;
     return res.redirect(req.buildRoute('pil.update'));
   });


### PR DESCRIPTION
Previously if the session had expired then this threw an error. Instead allow the session data to be re-created with the submission and the PIL application continued.