### PR TITLE
Prevent error when viewing autoresolved PPL holder change

### DIFF
--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -170,7 +170,7 @@ export default function Project({ task, schema }) {
     ),
 
     (
-      task.data.action === 'update' && (
+      task.data.action === 'update' && project.granted && (
         <StickyNavAnchor id="granted" key="granted">
           <h2><Snippet>sticky-nav.granted</Snippet></h2>
           <p><Snippet>versions.granted.info</Snippet></p>


### PR DESCRIPTION
If a change of PPL holder task auto resolves then it must be a draft, but we still send a notification with a link to the task, which currently fails because there's no granted version.