### PR TITLE
Remove per-request router creation

### DIFF
--- a/pages/common/routers/success.js
+++ b/pages/common/routers/success.js
@@ -25,22 +25,27 @@ module.exports = ({
   licence,
   type,
   status,
-  refModel
+  getStatus,
+  getModel = req => req.model
 } = {}) => {
   const app = Router();
 
   app.use((req, res, next) => {
+    const refModel = getModel(req, res);
     const user = getUserType(req);
+    if (typeof getStatus === 'function') {
+      status = getStatus(req, res);
+    }
     if (!status) {
-      status = get(refModel || req.model, 'openTasks[0].status');
+      status = get(refModel, 'openTasks[0].status');
     }
     if (!licence || !status) {
       return next();
     }
     if (!type) {
-      if (get(refModel || req.model, 'openTasks[0].data.action') === 'transfer') {
+      if (get(refModel, 'openTasks[0].data.action') === 'transfer') {
         type = 'transfer';
-      } else if (get(refModel || req.model, 'status') === 'active') {
+      } else if (get(refModel, 'status') === 'active') {
         type = 'amendment';
       } else {
         type = 'application';

--- a/pages/establishment/apply/index.js
+++ b/pages/establishment/apply/index.js
@@ -40,13 +40,10 @@ module.exports = settings => {
   });
 
   app.get('/success',
-    (req, res, next) => {
-      req.model = req.establishment;
-      next();
-    },
     success({
       model: 'establishment',
-      licence: 'pel'
+      licence: 'pel',
+      getModel: req => req.establishment
     })
   );
 

--- a/pages/pil/revoke/index.js
+++ b/pages/pil/revoke/index.js
@@ -16,13 +16,11 @@ module.exports = () => {
 
   app.use('/', update());
   app.use('/confirm', confirm());
-  app.use('/success', (req, res, next) => {
-    success({
-      licence: 'pil',
-      status: req.user.profile.asruUser ? 'resolved' : 'resubmitted',
-      type: 'revocation'
-    })(req, res, next);
-  });
+  app.use('/success', success({
+    licence: 'pil',
+    getStatus: req => req.user.profile.asruUser ? 'resolved' : 'resubmitted',
+    type: 'revocation'
+  }));
 
   return app;
 };

--- a/pages/project-version/convert/index.js
+++ b/pages/project-version/convert/index.js
@@ -24,11 +24,11 @@ module.exports = settings => {
       .catch(next);
   });
 
-  app.get('/success', (req, res, next) => success({
+  app.get('/success', success({
     licence: 'project',
     status: 'resolved',
     type: 'conversion'
-  })(req, res, next));
+  }));
 
   app.use((req, res) => res.sendResponse());
 

--- a/pages/project-version/update/success/index.js
+++ b/pages/project-version/update/success/index.js
@@ -12,10 +12,10 @@ module.exports = settings => {
     next();
   });
 
-  app.use((req, res, next) => success({
+  app.use(success({
     licence: 'project',
-    refModel: req.project
-  })(req, res, next));
+    getModel: req => req.project
+  }));
 
   app.use((req, res, next) => res.sendResponse());
 

--- a/pages/project/revoke/index.js
+++ b/pages/project/revoke/index.js
@@ -20,15 +20,15 @@ module.exports = () => {
 
   app.use('/confirm', confirm());
 
-  app.use('/success', (req, res, next) => {
-    success({
-      licence: 'project',
-      status: req.user.profile.asruUser
+  app.use('/success', success({
+    licence: 'project',
+    getStatus: req => {
+      return req.user.profile.asruUser
         ? req.user.profile.asruLicensing ? 'resolved' : 'inspector-recommended'
-        : 'resubmitted',
-      type: 'revocation'
-    })(req, res, next);
-  });
+        : 'resubmitted';
+    },
+    type: 'revocation'
+  }));
 
   return app;
 };

--- a/pages/project/update-licence-holder/index.js
+++ b/pages/project/update-licence-holder/index.js
@@ -16,12 +16,10 @@ module.exports = () => {
 
   app.use('/', update());
   app.use('/confirm', confirm());
-  app.use('/success', (req, res, next) => {
-    success({
-      licence: 'project',
-      status: req.project.status === 'inactive' ? 'licenceHolderUpdated' : null
-    })(req, res, next);
-  });
+  app.use('/success', success({
+    licence: 'project',
+    getStatus: req => req.project.status === 'inactive' ? 'licenceHolderUpdated' : null
+  }));
 
   return app;
 };


### PR DESCRIPTION
The way that dynamic statuses or models were configured they needed to create a complete router for every request. Move the dynamic bits into getter functions which are passed into the router constructor as params, and so can mount a single router instance.