### PR TITLE
Hide the experience questions when udpdating lh on a stub

### DIFF
--- a/pages/project/update-licence-holder/content/index.js
+++ b/pages/project/update-licence-holder/content/index.js
@@ -17,5 +17,8 @@ module.exports = {
       definedValues: 'Select a licence holder from the list',
       customValidate: 'Select a new PPL holder'
     }
+  },
+  notifications: {
+    success: 'Licence holder updated'
   }
 };

--- a/pages/project/update-licence-holder/routers/confirm.js
+++ b/pages/project/update-licence-holder/routers/confirm.js
@@ -27,7 +27,7 @@ module.exports = () => {
   app.use(form({
     requiresDeclaration: req => !req.user.profile.asruUser,
     locals(req, res, next) {
-      res.locals.static.fields = experienceFields.fields;
+      res.locals.static.fields = req.project.isLegacyStub ? [] : experienceFields.fields;
       res.locals.static.project = req.project;
       res.locals.static.values = get(req.session, `form.${req.model.id}.values`);
       req.api(`/establishment/${req.establishmentId}/profiles/${res.locals.static.values.licenceHolderId}`)
@@ -44,6 +44,13 @@ module.exports = () => {
   app.post('/', (req, res, next) => {
     sendData(req)
       .then(() => {
+        delete req.session.form[req.model.id];
+
+        if (req.project.isLegacyStub) {
+          req.notification({ key: 'success' });
+          return res.redirect(req.buildRoute('project.read'));
+        }
+
         res.redirect(req.buildRoute('project.updateLicenceHolder', { suffix: 'success' }));
       })
       .catch(next);

--- a/pages/project/update-licence-holder/routers/update.js
+++ b/pages/project/update-licence-holder/routers/update.js
@@ -15,10 +15,14 @@ module.exports = () => {
       req.api(`/establishment/${req.establishmentId}/profiles`, { query: { limit: 'all' } })
         .then(({ json: { data } }) => {
           req.form.schema = {
-            ...getSchema(data),
-            ...experienceFields.fieldNames.reduce((obj, field) => ({ ...obj, [field]: {} }), {})
+            ...getSchema(data)
           };
-          if (req.project.granted) {
+
+          if (!req.project.isLegacyStub) {
+            req.form.schema.experienceFields = experienceFields.fieldNames.reduce((obj, field) => ({ ...obj, [field]: {} }), {});
+          }
+
+          if (req.project.granted && !req.project.isLegacyStub) {
             req.form.schema.comments = {};
           }
         })
@@ -33,7 +37,7 @@ module.exports = () => {
     },
     locals(req, res, next) {
       res.locals.static.schema = omit(req.form.schema, [ ...experienceFields.fieldNames, 'comments' ]);
-      res.locals.static.fields = experienceFields.fields;
+      res.locals.static.fields = req.project.isLegacyStub ? [] : experienceFields.fields;
       res.locals.static.project = req.project;
       next();
     }

--- a/pages/project/update-licence-holder/views/confirm.jsx
+++ b/pages/project/update-licence-holder/views/confirm.jsx
@@ -39,7 +39,7 @@ const Confirm = ({ project, fields, values, proposedLicenceHolder, csrfToken }) 
       />
     </StaticRouter>
     {
-      project.status === 'active' && (
+      project.status === 'active' && !project.isLegacyStub && (
         <Fragment>
           <h3><Snippet>fields.comments.label</Snippet></h3>
           <p>

--- a/pages/project/update-licence-holder/views/index.jsx
+++ b/pages/project/update-licence-holder/views/index.jsx
@@ -39,7 +39,7 @@ const FormBody = ({ fields, values, formFields, setValue, submit, project }) => 
       ))
     }
     {
-      project.status === 'active' && <Fieldset model={values} schema={commentsSchema} />
+      project.status === 'active' && !project.isLegacyStub && <Fieldset model={values} schema={commentsSchema} />
     }
     <Button>
       <Snippet>buttons.submit</Snippet>


### PR DESCRIPTION
This action autoresolves so display a toaster instead of a success page.