### PR TITLE
Bugfix - missing profile task title

### DIFF
--- a/pages/task/read/content/profile.js
+++ b/pages/task/read/content/profile.js
@@ -2,6 +2,9 @@ const profile = require('../../../user/update/content');
 const { merge } = require('lodash');
 
 module.exports = merge({}, profile, {
+  title: {
+    amendment: 'Review amendment'
+  },
   'sticky-nav': {
     changes: 'Amendment requested',
     comments: 'Why are you making this amendment?'


### PR DESCRIPTION
* We extend base profile content, which has a title, which nukes the default