### PR TITLE
Add generic class for positioning csv downloads near tables

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -321,7 +321,7 @@ details {
   background-color: $blue;
 }
 
-.tab-content {
+.table-wrapper {
   position: relative;
   @include govuk-media-query($from: tablet) {
     .download {

--- a/pages/establishment/licence-fees/views/index.jsx
+++ b/pages/establishment/licence-fees/views/index.jsx
@@ -91,7 +91,7 @@ export default function Fees({ tab, tabs, children, subtitle = '' }) {
             tabs.map(({ page, key, ...props }, index) => <Link key={index} page={page} label={<Snippet>{key}</Snippet>} {...props} />)
           }
         </Tabs>
-        <div className="tab-content">
+        <div className="tab-content table-wrapper">
           <h2><Snippet>title</Snippet></h2>
           { children }
         </div>


### PR DESCRIPTION
Binding this style onto the tab content doesn't make sense when we have download links not in the context of tabs.

Add a generic "table-wrapper" class for positioning CSV download links near tables.