### PR TITLE
Restructure profile amendments content

### DIFF
--- a/pages/task/read/content/profile.js
+++ b/pages/task/read/content/profile.js
@@ -7,7 +7,9 @@ module.exports = merge({}, profile, {
   },
   'sticky-nav': {
     changes: 'Amendment requested',
-    comments: 'Why are you making this amendment?'
+    comments: {
+      amendment: 'Why are you making this amendment?'
+    }
   },
   'no-comments': 'No reason provided'
 });


### PR DESCRIPTION
Task pages lookup content for comments depending on task type, so the content needs to be scoepd under "amendment" (which is the only type of profile task)