### PR TITLE
Extract PDF renderer helper

### DIFF
--- a/pages/common/helpers/pdf.js
+++ b/pages/common/helpers/pdf.js
@@ -1,0 +1,32 @@
+import fetch from 'r2';
+
+module.exports = settings => ({ body, header, footer, hasStatusBanner }) => {
+
+  const params = {
+    method: 'POST',
+    json: {
+      template: body,
+      noRender: true,
+      pdfOptions: {
+        displayHeaderFooter: true,
+        headerTemplate: header,
+        footerTemplate: footer,
+        margin: {
+          top: hasStatusBanner ? 180 : 100,
+          left: 25,
+          right: 25,
+          bottom: 125
+        }
+      }
+    }
+  };
+
+  return fetch(`${settings.pdfService}/convert`, params).response
+    .then(response => {
+      if (response.status > 299) {
+        throw new Error(`Error generating PDF - generator responded ${response.status}`);
+      }
+      return response;
+    });
+
+};

--- a/pages/establishment/pdf/index.jsx
+++ b/pages/establishment/pdf/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createStore } from 'redux';
 import { Router } from 'express';
+import filenamify from 'filenamify';
 import { renderToStaticMarkup } from 'react-dom/server';
 import groupBy from 'lodash/groupBy';
 import Body from './views';
@@ -52,7 +53,7 @@ module.exports = settings => {
 
         pdf({ body, header, footer, hasStatusBanner })
           .then(response => {
-            res.attachment(`${establishment.name}.pdf`);
+            res.attachment(`${filenamify(establishment.name)}.pdf`);
             response.body.pipe(res);
           })
           .catch(next);

--- a/pages/pil/pdf/index.jsx
+++ b/pages/pil/pdf/index.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { createStore } from 'redux';
-import fetch from 'r2';
 import { Router } from 'express';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Body from './views';
 import Header from '../../common/views/pdf/header';
 import Footer from '../../common/views/pdf/footer';
 import content from './content';
+import PDF from '../../common/helpers/pdf';
 
 const stateReducer = (state = {}) => state;
 
 module.exports = settings => {
   const app = Router();
+  const pdf = PDF(settings);
 
   app.get('/', (req, res, next) => {
     const pil = {
@@ -27,39 +28,16 @@ module.exports = settings => {
     };
 
     const store = createStore(stateReducer, initialState);
-    const html = renderToStaticMarkup(<Body pil={pil} nonce={res.locals.static.nonce} content={content} />);
+    const body = renderToStaticMarkup(<Body pil={pil} nonce={res.locals.static.nonce} content={content} />);
     const header = renderToStaticMarkup(<Header store={store} model={pil} licenceType="pil" nonce={res.locals.static.nonce} />);
     const footer = renderToStaticMarkup(<Footer />);
 
     const hasStatusBanner = req.pil.status !== 'active';
 
-    const params = {
-      method: 'POST',
-      json: {
-        template: html,
-        pdfOptions: {
-          displayHeaderFooter: true,
-          headerTemplate: header,
-          footerTemplate: footer,
-          margin: {
-            top: hasStatusBanner ? 180 : 100,
-            left: 25,
-            right: 25,
-            bottom: 125
-          }
-        }
-      }
-    };
-
-    fetch(`${settings.pdfService}/convert`, params)
-      .response
+    pdf({ body, header, footer, hasStatusBanner })
       .then(response => {
-        if (response.status < 300) {
-          res.attachment(`${pil.licenceNumber}.pdf`);
-          response.body.pipe(res);
-        } else {
-          throw new Error(`Error generating PDF - generator responded ${response.status}`);
-        }
+        res.attachment(`${pil.licenceNumber}.pdf`);
+        response.body.pipe(res);
       })
       .catch(next);
   });


### PR DESCRIPTION
Extract a common PDF renderer component and reduce the amount of repeated rendering code used across page routers.

Adds a `noRender` option to all PDFs. This will prevent the PDF renderer assuming we're passing a mustache template and trying to check over a several megabyte string for a mustache token regex.