### PR TITLE
Allow users to apply for a new PIL if they leave an establishment

### DIFF
--- a/pages/pil/read/content/index.js
+++ b/pages/pil/read/content/index.js
@@ -24,6 +24,7 @@ module.exports = merge({}, baseContent, {
       button: 'Revoke licence'
     },
     reapply: {
+      summary: `## Apply for a new licence`,
       button: 'Reapply for licence'
     },
     amend: {

--- a/pages/pil/read/index.js
+++ b/pages/pil/read/index.js
@@ -44,6 +44,10 @@ module.exports = settings => {
   });
 
   app.get('/', (req, res, next) => {
+    if (req.model.status === 'revoked' && res.locals.static.canUpdate) {
+      // users can't reactivate a PIL if they're no longer at the establishment that holds it
+      res.locals.static.canReapply = !!req.profile.establishments.find(e => e.id === req.model.establishmentId);
+    }
     res.locals.static.pil = req.model;
     res.locals.static.openTask = req.model.openTasks[0];
     res.locals.static.profile = req.profile;

--- a/pages/pil/read/views/index.jsx
+++ b/pages/pil/read/views/index.jsx
@@ -195,7 +195,7 @@ const PIL = ({
                       </section>
                     }
                     {
-                      pil.status === 'revoked' && !canReapply &&
+                      pil.status === 'revoked' && !canReapply && profile.over18 &&
                       <section className="apply-licence">
                         <Snippet>{`action.reapply.summary`}</Snippet>
                         <Link

--- a/pages/pil/read/views/index.jsx
+++ b/pages/pil/read/views/index.jsx
@@ -19,6 +19,7 @@ const PIL = ({
   pil,
   profile,
   canUpdate,
+  canReapply,
   allowedActions,
   canDownload,
   openTask,
@@ -158,17 +159,18 @@ const PIL = ({
               {
                 !openTask &&
                   <Fragment>
-                    <section className="amend-licence">
-                      <Snippet>{`action.amend.${isLicenceHolder ? 'licenceHolder' : 'other'}.summary`}</Snippet>
-                      <Link
-                        page="pil.update"
-                        className="govuk-button button-secondary"
-                        establishmentId={pil.establishmentId}
-                        label={<Snippet>{amendButtonSnippet}</Snippet>}
-                      />
-                    </section>
                     {
                       pil.status === 'active' &&
+                      <Fragment>
+                        <section className="amend-licence">
+                          <Snippet>{`action.amend.${isLicenceHolder ? 'licenceHolder' : 'other'}.summary`}</Snippet>
+                          <Link
+                            page="pil.update"
+                            className="govuk-button button-secondary"
+                            establishmentId={pil.establishmentId}
+                            label={<Snippet>{amendButtonSnippet}</Snippet>}
+                          />
+                        </section>
                         <section className="revoke-licence">
                           <Snippet>action.revoke.summary</Snippet>
                           <Link
@@ -178,6 +180,30 @@ const PIL = ({
                             label={<Snippet>action.revoke.button</Snippet>}
                           />
                         </section>
+                      </Fragment>
+                    }
+                    {
+                      pil.status === 'revoked' && canReapply &&
+                      <section className="amend-licence">
+                        <Snippet>{`action.amend.${isLicenceHolder ? 'licenceHolder' : 'other'}.summary`}</Snippet>
+                        <Link
+                          page="pil.update"
+                          className="govuk-button button-secondary"
+                          establishmentId={pil.establishmentId}
+                          label={<Snippet>action.reapply.button</Snippet>}
+                        />
+                      </section>
+                    }
+                    {
+                      pil.status === 'revoked' && !canReapply &&
+                      <section className="apply-licence">
+                        <Snippet>{`action.reapply.summary`}</Snippet>
+                        <Link
+                          page="pil.create"
+                          className="govuk-button button-secondary"
+                          label={<Snippet>action.reapply.button</Snippet>}
+                        />
+                      </section>
                     }
                   </Fragment>
               }
@@ -193,6 +219,7 @@ const mapStateToProps = ({
   static: {
     profile,
     canUpdate,
+    canReapply,
     canDownload,
     pil,
     openTask,
@@ -206,6 +233,7 @@ const mapStateToProps = ({
   pil,
   profile,
   canUpdate,
+  canReapply,
   canDownload,
   allowedActions,
   openTask,

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -1,5 +1,6 @@
 const { reduce, isUndefined } = require('lodash');
 const { Router } = require('express');
+const differenceInYears = require('date-fns/difference_in_years');
 const { schema } = require('./list/schema');
 const { cleanModel } = require('../../lib/utils');
 
@@ -25,6 +26,7 @@ module.exports = settings => {
       .then(({ json: { data, meta } }) => {
         const model = cleanModel(data);
         model.openTasks = meta.openTasks;
+        model.over18 = model.dob && differenceInYears(new Date(), new Date(model.dob)) >= 18;
         req.model = model;
         req.profile = model;
         req.profileId = profileId;


### PR DESCRIPTION
Currently if a user has left the establishment that they once held a PIL at (and it is revoked) then they can't easily reapply for a new licence.

Add an extra check to revoked licences that the user is still at the PIL holding establishment, and present different paths forward depending on the case - either reactivating an old PIL or creating a new one.