### PR TITLE
Bugfix - pdf images fixes

### DIFF
--- a/pages/common/assets/sass/pdf/index.scss
+++ b/pages/common/assets/sass/pdf/index.scss
@@ -16,6 +16,8 @@ $sectionSeparator: 50px;
 .editor {
   img {
     max-width: 100%;
+    page-break-inside: avoid;
+    max-height: 100vh;
   }
 }
 
@@ -187,7 +189,7 @@ dl dd {
   &:not(.adverse-effects) {
     page-break-before: always;
   }
-  
+
   page-break-after: always;
 
   .field {


### PR DESCRIPTION
* Set mav height to 100vh to prevent images splitting over pages
* Avoid page breaks in images