### PR TITLE
Bugfix - deleting comments

### DIFF
--- a/pages/project-version/index.js
+++ b/pages/project-version/index.js
@@ -66,7 +66,7 @@ module.exports = settings => {
     };
     req.api(`/task/${taskId}/comment`, params)
       .then(response => {
-        const id = get(response, 'json.data.json.data.activityLog[0].id');
+        const id = get(response, 'json.data.json.data.comments[0].id');
         res.json({ id });
       })
       .catch(next);


### PR DESCRIPTION
When a comment was added we would assign the id from the most recent activity log entry, not the most recent comment. This would prevent comments being deleted until page reloaded