### PR TITLE
Add link to PIL list to review success page

### DIFF
--- a/pages/common/views/success.jsx
+++ b/pages/common/views/success.jsx
@@ -1,19 +1,34 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { Success, Snippet } from '@asl/components';
+import { useSelector } from 'react-redux';
+import { Panel, Snippet, Link } from '@asl/components';
 
-const Index = ({ profile = {} }) => (
-  <div className="govuk-grid-row">
+const Index = ({ onwardLink }) => {
+  const profile = useSelector(state => state.static.profile);
+  const subtitle = <Snippet optional email={profile.email}>{`success.subtitle`}</Snippet>;
+  const nextSteps = <Snippet optional>{`success.body`}</Snippet>;
+
+  return <div className="govuk-grid-row">
     <div className="govuk-grid-column-two-thirds">
-      <Success
-        title={<Snippet>{`success.title`}</Snippet>}
-        subtitle={<Snippet optional email={profile.email}>{`success.subtitle`}</Snippet>}
-        nextSteps={<Snippet optional>{`success.body`}</Snippet>}
-      />
+      <Panel title={<Snippet>{`success.title`}</Snippet>} className="green-bg">
+        {
+          subtitle && <h2>{ subtitle }</h2>
+        }
+      </Panel>
+
+      {
+        nextSteps && (
+          <div className="what-next">
+            <h2><Snippet>success.whatNext.title</Snippet></h2>
+            <p>{ nextSteps }</p>
+          </div>
+        )
+      }
+
+      {
+        onwardLink || <Link page="dashboard" label={<Snippet>breadcrumbs.dashboard</Snippet>} />
+      }
     </div>
-  </div>
-);
+  </div>;
+};
 
-const mapStateToProps = ({ static: { profile } }) => ({ profile });
-
-export default connect(mapStateToProps)(Index);
+export default Index;

--- a/pages/pil/review/views/success.jsx
+++ b/pages/pil/review/views/success.jsx
@@ -1,3 +1,12 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Link, Snippet } from '@asl/components';
 import Success from '../../../common/views/success';
 
-export default Success;
+export default (...props) => {
+  const allowedActions = useSelector(state => state.static.allowedActions);
+  const canViewPils = allowedActions.includes('pil.list');
+  const onwardLink = canViewPils ? <Link page="pils" label={<Snippet>breadcrumbs.pils</Snippet>} /> : null;
+
+  return <Success onwardLink={ onwardLink } />;
+};


### PR DESCRIPTION
If a user has permissions to view the PIL list then replace the "Home" link that lives on the success page by default with a link to the PIL list for the establishment.

Also moves the success page component fully into this repo. 100% of instances of the success page in the app load `./pages/common/views/success.jsx` from this repo, which was delegating directly to `@asl/components`, but this extra abstraction doesn't seem to add any value except to make development more involved.