### PR TITLE
Merge all task list content in related task router

### DIFF
--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -1,7 +1,3 @@
-const taskListFields = require('../../task/list/content/fields');
-const taskStatus = require('../../task/content/status');
-const tasks = require('../../task/content/tasks');
-
 module.exports = {
   siteTitle: 'Research and testing using animals',
   beta: 'This is a new service - your [feedback](mailto:ASPELQueries@homeoffice.gov.uk) will help us to improve it.',
@@ -154,8 +150,7 @@ module.exports = {
   fields: {
     declaration: {
       label: 'By submitting this change, I confirm that I also have the consent of the Establishment Licence holder'
-    },
-    ...taskListFields
+    }
   },
   errors: {
     heading: 'Please fix the following error',
@@ -236,11 +231,5 @@ module.exports = {
   relatedTasks: {
     unavailable: 'Related tasks unavailable',
     noTasks: 'There are no related tasks.'
-  },
-  status: {
-    ...taskStatus
-  },
-  tasks: {
-    ...tasks
   }
 };

--- a/pages/common/routers/related-tasks.js
+++ b/pages/common/routers/related-tasks.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 const { merge } = require('lodash');
 const datatable = require('./datatable');
+const content = require('../../task/list/content');
 const taskListSchema = require('../../task/list/schema');
 
 module.exports = getQuery => {
@@ -45,6 +46,10 @@ module.exports = getQuery => {
       let query = getQuery(req);
       query = merge(query, req.query);
       req.datatable.apiPath = ['/tasks/related', { query }];
+      next();
+    },
+    locals: (req, res, next) => {
+      res.locals.static.content = merge({}, res.locals.static.content, content);
       next();
     },
     errorHandler: (err, req, res, next) => {


### PR DESCRIPTION
Some content was being added to the common content file, but not all things.

Take the task list content out of the common file so it is not loaded when related tasks are not shown, and merge the entire task list content file when related tasks are loaded.