### PR TITLE
Fix bugs with RA condition in NTS downloads

### DIFF
--- a/pages/project-version/pdf/views/nts/components/retrospective-assessment.jsx
+++ b/pages/project-version/pdf/views/nts/components/retrospective-assessment.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import RAContent from '@asl/projects/client/constants/retrospective-assessment';
 
-export default function RetrospectiveAssessment({ project }) {
-  return <p>{ project.retrospectiveAssessmentRequired ? RAContent.required : RAContent.notRequired }</p>;
+export default function RetrospectiveAssessment({ version }) {
+  return <p>{ version.retrospectiveAssessment ? RAContent.required : RAContent.notRequired }</p>;
 }

--- a/pages/project-version/pdf/views/nts/v0.jsx
+++ b/pages/project-version/pdf/views/nts/v0.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import ReviewField from '@asl/projects/client/components/review-field';
 import RichText from '@asl/projects/client/components/editor';
 import schemaV0 from '@asl/projects/client/schema/v0';
+import RetrospectiveAssessment from './components/retrospective-assessment';
 
 const getPurposeOptions = () => {
   return schemaV0().programmeOfWork.subsections.purpose.fields.find(field => field.name === 'purpose').options;
@@ -34,6 +35,11 @@ export default function SchemaV0() {
           project={version}
           options={getPurposeOptions()}
         />
+      </div>
+
+      <div className="q-and-a">
+        <h2>Retrospective assessment</h2>
+        <RetrospectiveAssessment version={version} />
       </div>
 
       <h2>Objectives and benefits</h2>

--- a/pages/project-version/pdf/views/nts/v1.jsx
+++ b/pages/project-version/pdf/views/nts/v1.jsx
@@ -46,7 +46,6 @@ function SpeciesCount({ version }) {
 }
 
 export default function SchemaV1() {
-  const project = useSelector(state => state.application.project);
   const version = useSelector(state => state.project);
 
   return (
@@ -81,8 +80,8 @@ export default function SchemaV1() {
       <SpeciesTable version={version} />
 
       <div className="q-and-a">
-        <h2>Retrospective asessment</h2>
-        <RetrospectiveAssessment project={project} />
+        <h2>Retrospective assessment</h2>
+        <RetrospectiveAssessment version={version} />
       </div>
 
       <h2>Objectives and benefits</h2>


### PR DESCRIPTION
* RA condition is dependent on `retrospectiveAssessment` property, and not `retrospectiveAssessmentRequired` (which flags if it is non-optional)
* RA property is on version and not project
* RA section was missing from legacy NTS
* Fix typo