### PR TITLE
Include checksum in project patch response

### DIFF
--- a/pages/project-version/update/router.js
+++ b/pages/project-version/update/router.js
@@ -72,7 +72,8 @@ module.exports = settings => {
       }
     };
     req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.version.id}/patch`, opts)
-      .then(({ json: { data } }) => {
+      .then(({ json: { data, meta } }) => {
+        req.version.checksum = meta.checksum;
         req.version.data = data.data;
       })
       .then(() => next())
@@ -86,7 +87,7 @@ module.exports = settings => {
   });
 
   app.put('/', getAllChanges(), (req, res) => {
-    res.json({ changes: res.locals.static.changes });
+    res.json({ changes: res.locals.static.changes, checksum: req.version.checksum });
   });
 
   app.use((req, res, next) => res.sendResponse());


### PR DESCRIPTION
Allows the client to detect remote changes when patching projects.