### PR TITLE
Disable "full application" for legacy PPLs

### DIFF
--- a/pages/project-version/pdf/index.jsx
+++ b/pages/project-version/pdf/index.jsx
@@ -30,7 +30,7 @@ module.exports = settings => {
         isGranted: true,
         readonly: true,
         showConditions: !isFullApplication,
-        isFullApplication
+        isFullApplication: isFullApplication && req.project.schemaVersion > 0
       },
       static: {
         content,


### PR DESCRIPTION
The legacy PPL already is the full application, and so the logic inside projects causes lots of content to end up repeated if it is a legacy project _and_ the `isFullApplication` flag is set.

Set `isFullApplication` to false always for legacy PPL PDFs so that the content is not repeated.