### PR TITLE
Remove official sensitive warning from NTS pdf download

### DIFF
--- a/pages/common/views/pdf/footer.jsx
+++ b/pages/common/views/pdf/footer.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Wrapper from './wrapper';
 
-const Footer = () => (
+const Footer = ({ officialSensitive = true }) => (
   <Wrapper name="footer">
     <footer>
-      <p><strong>Handling Instructions:</strong> Contains personal sensitive information, subject to confidentiality requirements under the Data Protection Act.  This should only be circulated in accordance with ASPA Guidance. All government information may be subject to an FOI request and subsequent assessment.</p>
+      {
+        officialSensitive && <p><strong>Handling Instructions:</strong> Contains personal sensitive information, subject to confidentiality requirements under the Data Protection Act.  This should only be circulated in accordance with ASPA Guidance. All government information may be subject to an FOI request and subsequent assessment.</p>
+      }
       <p className="page-number">Page <span className="pageNumber"></span> of <span className="totalPages"></span></p>
     </footer>
   </Wrapper>

--- a/pages/common/views/pdf/header.jsx
+++ b/pages/common/views/pdf/header.jsx
@@ -7,7 +7,7 @@ import ProjectStatusBanner from '../../../project-version/components/project-sta
 
 const format = date => moment(date).format('DD MMM YY');
 
-const Header = ({ store, model, licenceType, nonce, version }) => (
+const Header = ({ store, model, licenceType, nonce, version, officialSensitive = true }) => (
   <Wrapper name="header" nonce={nonce}>
     <Provider store={store}>
       <header className="pdf-header">
@@ -16,8 +16,9 @@ const Header = ({ store, model, licenceType, nonce, version }) => (
             ? <ProjectStatusBanner model={model} version={version} isPdf={true} />
             : <LicenceStatusBanner licence={model} licenceType={licenceType} isPdf={true} />
         }
-
-        <p className="float-left">OFFICIAL - SENSITIVE</p>
+        {
+          officialSensitive && <p className="float-left">OFFICIAL - SENSITIVE</p>
+        }
 
         <p className="float-right">
           { model.licenceNumber &&

--- a/pages/project-version/pdf/index.jsx
+++ b/pages/project-version/pdf/index.jsx
@@ -43,8 +43,17 @@ module.exports = settings => {
     req.pdf.store = createStore(initialState);
     req.pdf.nonce = res.locals.static.nonce;
 
-    req.pdf.header = renderToStaticMarkup(<Header store={req.pdf.store} model={req.project} licenceType="ppl" nonce={req.pdf.nonce} version={req.version} />);
-    req.pdf.footer = renderToStaticMarkup(<Footer />);
+    req.pdf.header = renderToStaticMarkup(<Header
+      store={req.pdf.store}
+      model={req.project}
+      licenceType="ppl"
+      nonce={req.pdf.nonce}
+      version={req.version}
+      officialSensitive={req.pdf.officialSensitive}
+    />);
+    req.pdf.footer = renderToStaticMarkup(<Footer
+      officialSensitive={req.pdf.officialSensitive}
+    />);
     req.pdf.hasStatusBanner = req.project.status !== 'active' || (req.project.status === 'active' && req.project.granted.id !== req.version.id);
 
     next();
@@ -78,7 +87,7 @@ module.exports = settings => {
   };
 
   app.get('/nts',
-    setupPdf(),
+    setupPdf({ officialSensitive: false }),
     renderNts,
     convertToPdf
   );


### PR DESCRIPTION
Make the official sensitive content in the header and footer of PDF downloads optional - defaulting to true, and remove it specifically from NTS document.