### PR TITLE
Reformat dates in table contexts

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -1,7 +1,8 @@
 module.exports = {
   dateFormat: {
     short: 'DD/MM/YYYY',
-    medium: 'DD MMMM YYYY',
+    medium: 'D MMM YYYY',
+    long: 'DD MMMM YYYY',
     datetime: 'DD MMMM YYYY HH:mm'
   }
 };

--- a/pages/establishment/licence-fees/personal/views/row.jsx
+++ b/pages/establishment/licence-fees/personal/views/row.jsx
@@ -30,7 +30,7 @@ function UpdatingForm({ id, waived, onCancelClick, formFields }) {
 }
 
 function Waiver({ waivedBy, updatedAt, comment }) {
-  const timestamp = format(updatedAt, dateFormat.medium);
+  const timestamp = format(updatedAt, dateFormat.long);
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-three-quarters">

--- a/pages/establishment/licence-fees/views/index.jsx
+++ b/pages/establishment/licence-fees/views/index.jsx
@@ -58,8 +58,8 @@ export default function Fees({ tab, tabs, children, subtitle = '' }) {
         />
         <p className="subtitle">
           <Snippet
-            start={format(fees.startDate, dateFormat.medium)}
-            end={format(fees.endDate, dateFormat.medium)}
+            start={format(fees.startDate, dateFormat.long)}
+            end={format(fees.endDate, dateFormat.long)}
           >
             fees.period
           </Snippet>

--- a/pages/global-profile/views/index.jsx
+++ b/pages/global-profile/views/index.jsx
@@ -112,7 +112,7 @@ export default function Index({ dedupe, AsruRolesComponent, children }) {
             <Fragment>
               <dt>Date of birth:</dt>
               <dd>
-                { formatDate(model.dob, dateFormat.medium) }
+                { formatDate(model.dob, dateFormat.long) }
                 {
                   isOwnProfile && (
                     <Fragment>

--- a/pages/pil/dashboard/views/index.jsx
+++ b/pages/pil/dashboard/views/index.jsx
@@ -98,7 +98,7 @@ const Index = ({ schema, establishment, certificates, exemptions, model, isAsru,
       schema: { ...certificatesSchema, ...modulesSchema, ...speciesSchema },
       formatters: {
         passDate: {
-          format: date => formatDate(date, dateFormat.medium)
+          format: date => formatDate(date, dateFormat.long)
         },
         modules: {
           format: modules => (

--- a/pages/pil/read/views/index.jsx
+++ b/pages/pil/read/views/index.jsx
@@ -35,18 +35,18 @@ const PIL = ({
 
   const formatters = {
     issueDate: {
-      format: issueDate => formatDate(issueDate, dateFormat.medium)
+      format: issueDate => formatDate(issueDate, dateFormat.long)
     },
     updatedAt: {
       format: (updatedAt, pil) => differenceInCalendarDays(updatedAt, pil.issueDate) > 0
-        ? formatDate(updatedAt, dateFormat.medium)
+        ? formatDate(updatedAt, dateFormat.long)
         : '-'
     },
     revocationDate: {
-      format: revocationDate => formatDate(revocationDate, dateFormat.medium)
+      format: revocationDate => formatDate(revocationDate, dateFormat.long)
     },
     reviewDate: {
-      format: reviewDate => formatDate(reviewDate, dateFormat.medium)
+      format: reviewDate => formatDate(reviewDate, dateFormat.long)
     },
     establishment: {
       format: e => e && e.name ? e.name : 'This licence is held at another establishment.'

--- a/pages/profile/convert-legacy-project/views/confirm.jsx
+++ b/pages/profile/convert-legacy-project/views/confirm.jsx
@@ -7,7 +7,7 @@ import { formatDate } from '../../../../lib/utils';
 
 const formatters = {
   issueDate: {
-    format: issueDate => formatDate(issueDate, dateFormat.medium)
+    format: issueDate => formatDate(issueDate, dateFormat.long)
   },
   duration: {
     format: duration => {

--- a/pages/profile/invitations/views/index.jsx
+++ b/pages/profile/invitations/views/index.jsx
@@ -31,6 +31,7 @@ const formatters = {
         return (
           <ExpiryDate
             date={date}
+            dateFormat={dateFormat.medium}
             expiry={addDays(date, 7)}
             showNotice={7}
             showUrgent={3}

--- a/pages/profile/read/views/index.jsx
+++ b/pages/profile/read/views/index.jsx
@@ -41,7 +41,7 @@ const Index = ({
               {
                 model.dob && isOwnProfile && <Fragment>
                   <dt>Date of birth:</dt>
-                  <dd>{ formatDate(model.dob, dateFormat.medium) }</dd>
+                  <dd>{ formatDate(model.dob, dateFormat.long) }</dd>
                 </Fragment>
               }
             </dl>

--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -67,7 +67,7 @@ class Profile extends React.Component {
                         <Snippet
                           expiryDate={formatDate(
                             project.expiryDate,
-                            dateFormat.medium
+                            dateFormat.long
                           )}
                         >
                           projects.expiryDate

--- a/pages/project-version/components/project-status-banner.jsx
+++ b/pages/project-version/components/project-status-banner.jsx
@@ -11,8 +11,8 @@ export default function ProjectStatusBanner({ model, version, isPdf }) {
     return (
       <LicenceStatusBanner title={<Snippet>invalidLicence.status.transferred</Snippet>} licence={model} licenceType="ppl" version={version.id} isPdf={isPdf} colour="red">
         <ul className="licence-dates">
-          <li><strong>Granted: </strong> <span>{ format(model.issueDate, dateFormat.medium) }</span></li>
-          <li><strong>Transferred out: </strong><span>{ format(model.transferredOutDate, dateFormat.medium) }</span></li>
+          <li><strong>Granted: </strong> <span>{ format(model.issueDate, dateFormat.long) }</span></li>
+          <li><strong>Transferred out: </strong><span>{ format(model.transferredOutDate, dateFormat.long) }</span></li>
         </ul>
         <p><Snippet>invalidLicence.summary.transferred</Snippet></p>
         {
@@ -46,7 +46,7 @@ export default function ProjectStatusBanner({ model, version, isPdf }) {
       <LicenceStatusBanner title={<Snippet>{`invalidLicence.status.${superseded ? 'superseded' : 'draft'}`}</Snippet>} licence={model} colour={superseded && 'red'} isPdf={isPdf}>
         <Fragment>
           {
-            superseded && <p><strong>This version was valid from {format(isFirstVersion ? model.issueDate : version.updatedAt, dateFormat.medium)} until {format(nextVersion.updatedAt, dateFormat.medium)}</strong></p>
+            superseded && <p><strong>This version was valid from {format(isFirstVersion ? model.issueDate : version.updatedAt, dateFormat.long)} until {format(nextVersion.updatedAt, dateFormat.long)}</strong></p>
           }
           <p><Snippet>{`invalidLicence.summary.${superseded ? 'superseded' : 'ppl_active'}`}</Snippet></p>
           <p><Link page="projectVersion" versionId={model.granted.id} label={<Snippet>{'invalidLicence.view'}</Snippet>} /></p>

--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -349,7 +349,7 @@ function PreviousVersions({ model }) {
                 <Link
                   page="projectVersion"
                   versionId={v.id}
-                  label={<Snippet type={type} updatedAt={formatDate(updatedAt, dateFormat.medium)}>previousVersions.version</Snippet>}
+                  label={<Snippet type={type} updatedAt={formatDate(updatedAt, dateFormat.long)}>previousVersions.version</Snippet>}
                 />
               </li>
             );

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -62,7 +62,7 @@ const LogItem = ({ log, task }) => {
 
   return (
     <div className="log-item">
-      <span className="date">{format(log.createdAt, dateFormat.medium)}</span>
+      <span className="date">{format(log.createdAt, dateFormat.long)}</span>
       {getStatusBadge(status)}
       {getAuthor(log.changedBy, action, status, task)}
       {(status === 'inspector-recommended' || status === 'inspector-rejected') && getRecommendation(status)}

--- a/pages/task/read/views/components/deadline.jsx
+++ b/pages/task/read/views/components/deadline.jsx
@@ -12,7 +12,7 @@ class Deadline extends Component {
       <div className="deadline">
         <h2><Snippet>sticky-nav.deadline</Snippet></h2>
 
-        <h3>{ formatDate(task.deadline, dateFormat.medium) }</h3>
+        <h3>{ formatDate(task.deadline, dateFormat.long) }</h3>
 
         { this.props.isInspector && task.isExtendable &&
           <Fragment>

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -190,7 +190,7 @@ export default function Project({ task, schema }) {
                 <dd>
                   {
                     item['expiry-date']
-                      ? format(item['expiry-date'], dateFormat.medium)
+                      ? format(item['expiry-date'], dateFormat.long)
                       : <em>No answer provided</em>
                   }
                 </dd>


### PR DESCRIPTION
Adds a new `long` date format (which is the same as the old `medium`) and sets `medium` to use truncated months.

Use `medium` in table contexts to save space and `long` in non-table contexts.