### PR TITLE
Validate UUID url parameters

### DIFF
--- a/pages/common/middleware/index.js
+++ b/pages/common/middleware/index.js
@@ -1,4 +1,6 @@
+const isUUID = require('uuid-validate');
 const { get, set } = require('lodash');
+const { NotFoundError } = require('@asl/service/errors');
 
 const hydrate = () => (req, res, next) => {
   const task = get(req.model, 'openTasks[0]');
@@ -89,10 +91,18 @@ const populateNamedPeople = (req, res, next) => {
   next();
 };
 
+const validateUuidParam = () => (req, res, next, param) => {
+  if (!isUUID(param)) {
+    return next(new NotFoundError());
+  }
+  next();
+};
+
 module.exports = {
   hydrate,
   updateDataFromTask,
   redirectToTaskIfOpen,
   clearSessionIfNotFromTask,
-  populateNamedPeople
+  populateNamedPeople,
+  validateUuidParam
 };

--- a/pages/place/index.js
+++ b/pages/place/index.js
@@ -2,12 +2,14 @@ const { Router } = require('express');
 const { cleanModel } = require('../../lib/utils');
 const { populateNamedPeople } = require('../common/middleware');
 const routes = require('./routes');
+const { validateUuidParam } = require('../common/middleware');
 
 module.exports = settings => {
   const app = Router({ mergeParams: true });
 
   app.use(populateNamedPeople);
 
+  app.param('placeId', validateUuidParam());
   app.param('placeId', (req, res, next, placeId) => {
     const params = req.path.match(/delete\/success$/)
       ? { query: { withDeleted: true } }

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -3,6 +3,7 @@ const { Router } = require('express');
 const differenceInYears = require('date-fns/difference_in_years');
 const { schema } = require('./list/schema');
 const { cleanModel } = require('../../lib/utils');
+const { validateUuidParam } = require('../common/middleware');
 
 const routes = require('./routes');
 
@@ -21,7 +22,11 @@ module.exports = settings => {
       req.model.id = 'new-profile';
       return next('route');
     }
+    next();
+  });
 
+  app.param('profileId', validateUuidParam());
+  app.param('profileId', (req, res, next, profileId) => {
     return req.api(`/establishment/${req.establishmentId}/profile/${profileId}`)
       .then(({ json: { data, meta } }) => {
         const model = cleanModel(data);

--- a/pages/project/index.js
+++ b/pages/project/index.js
@@ -1,7 +1,6 @@
 const { Router } = require('express');
-const isUUID = require('uuid-validate');
-const { NotFoundError } = require('@asl/service/errors');
 const routes = require('./routes');
+const { validateUuidParam } = require('../common/middleware');
 
 module.exports = settings => {
   const app = Router({ mergeParams: true });
@@ -10,9 +9,11 @@ module.exports = settings => {
     if (projectId === 'create' || projectId === 'import') {
       return next('route');
     }
-    if (!isUUID(projectId)) {
-      return next(new NotFoundError());
-    }
+    next();
+  });
+
+  app.param('projectId', validateUuidParam());
+  app.param('projectId', (req, res, next, projectId) => {
     req.projectId = projectId;
     return req.api(`/establishment/${req.establishmentId}/projects/${projectId}`)
       .then(({ json: { data, meta } }) => {

--- a/pages/task/index.js
+++ b/pages/task/index.js
@@ -1,9 +1,11 @@
 const { Router } = require('express');
 const routes = require('./routes');
+const { validateUuidParam } = require('../common/middleware');
 
 module.exports = settings => {
   const app = Router();
 
+  app.param('taskId', validateUuidParam());
   app.param('taskId', (req, res, next, taskId) => {
     return req.api(`/tasks/${taskId}`)
       .then(response => {


### PR DESCRIPTION
Check that UUIDs are the correct format before making a call to the API, and throw 404 if not.

Certain unchecked inputs can cause the http client to throw if used in API request URLs, so validate the user input from the URL before making a call using it.