### PR TITLE
Unset status label on PIL tasks

### DIFF
--- a/pages/task/read/content/pil.js
+++ b/pages/task/read/content/pil.js
@@ -40,6 +40,7 @@ module.exports = merge({}, baseContent, {
   },
   fields: {
     status: {
+      label: '',
       'with-ntco': ''
     },
     comment: {


### PR DESCRIPTION
The PIL content inherits a label for `status` which then appears erroneously in the next steps section of a PIL task.

Ensure this is unset correctly for PIL tasks and not inherited.