### PR TITLE
Fix semver comparator

### DIFF
--- a/pages/project-version/update/router.js
+++ b/pages/project-version/update/router.js
@@ -78,7 +78,7 @@ module.exports = settings => {
   app.put('/', (req, res, next) => {
     const clientVersion = req.get('x-projects-version');
     const requiredVersion = dependencies['@asl/projects'];
-    if (semver.major(clientVersion) !== semver.major(requiredVersion)) {
+    if (semver.diff(clientVersion, semver.minVersion(requiredVersion)) === 'major') {
       res.status(400);
       return res.json({ message: 'Update required', code: 'UPDATE_REQUIRED' });
     }


### PR DESCRIPTION
The required version is a range, and not an explicit version so it needs to be converted to an explicit version before it can be used as an argument in version comparison.