### PR TITLE
Redirect change email confirm page on session expiry

### DIFF
--- a/pages/user/update-email/routers/confirm.js
+++ b/pages/user/update-email/routers/confirm.js
@@ -1,10 +1,14 @@
 const { Router } = require('express');
-const { pick, set } = require('lodash');
+const { pick, get, set } = require('lodash');
 
 module.exports = () => {
   const app = Router();
 
   app.use((req, res, next) => {
+    if (!get(req.session, `form[${req.model.id}].values`)) {
+      return res.redirect(req.buildRoute('account.updateEmail'));
+    }
+
     if (req.query.edit) {
       return res.redirect(req.buildRoute('account.updateEmail'));
     }


### PR DESCRIPTION
This currently throws an error if the user attempts to access the confirm page when the values are not present on the session. Instead redirect to the previous page and allow a restart.