### PR TITLE
Remove "over 18" component from some PIL tasks

### DIFF
--- a/pages/task/read/views/models/pil.jsx
+++ b/pages/task/read/views/models/pil.jsx
@@ -57,14 +57,16 @@ export default function PIL({ task, values }) {
     <StickyNavAnchor id={applicantKey} key={applicantKey}>
       <h2><Snippet>{`sticky-nav.${applicantKey}`}</Snippet></h2>
       <p><Link page="profile.read" establishmentId={task.data.establishmentId} profileId={profile.id} label={`${profile.firstName} ${profile.lastName}`} /></p>
-      <dl>
-        <dt><Snippet>pil.applicant.over18</Snippet></dt>
-        <dd>{
-          over18 === 'unknown'
-            ? <Snippet>pil.applicant.missingDob</Snippet>
-            : over18 === true ? 'Yes' : 'No'
-        }</dd>
-      </dl>
+      {
+        task.type === 'application' && <dl>
+          <dt><Snippet>pil.applicant.over18</Snippet></dt>
+          <dd>{
+            over18 === 'unknown'
+              ? <Snippet>pil.applicant.missingDob</Snippet>
+              : over18 === true ? 'Yes' : 'No'
+          }</dd>
+        </dl>
+      }
     </StickyNavAnchor>,
 
     <StickyNavAnchor id="procedures" key="procedures">


### PR DESCRIPTION
Where the PIL task is not an application then do not show the "over 18" component on the task screen.