### PR TITLE
Pass `withDeleted` flag when fetching version

### DIFF
--- a/pages/task/read/routers/read.js
+++ b/pages/task/read/routers/read.js
@@ -41,10 +41,9 @@ module.exports = () => {
             versionId = req.project.granted.id;
           }
           if (versionId) {
-            return req.api(`${url}/project-version/${versionId}`)
+            return req.api(`${url}/project-version/${versionId}`, { query: { withDeleted: true } })
               .then(({ json: { data } }) => {
                 req.version = data;
-
               });
           }
         })


### PR DESCRIPTION
If a task is discarded then the version is deleted. So without this the success page throws a 404.