### PR TITLE
Improvements to statutory deadlines in task view

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,4 +1,5 @@
 const dateFormatter = require('date-fns/format');
+const differenceInDays = require('date-fns/difference_in_days');
 const { get, isEqual, mapValues, isPlainObject, omit, castArray, reduce, isUndefined } = require('lodash');
 const { parse } = require('url');
 const qs = require('qs');
@@ -127,8 +128,16 @@ const canTransferPil = ({ pil, user }) => {
 
 const formatDate = (date, format) => date ? dateFormatter(date, format) : '-';
 
+const daysSinceDate = (date, from = new Date()) => differenceInDays(from, date);
+
 const numberWithCommas = x => {
   return x && x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};
+
+const isDeadlineExtension = (item) => {
+  const extensionFlag = 'event.meta.payload.data.deadline.isExtended';
+  const bcExtensionFlag = 'event.meta.payload.data.extended';
+  return get(item, extensionFlag) || get(item, bcExtensionFlag, false);
 };
 
 module.exports = {
@@ -145,7 +154,9 @@ module.exports = {
   buildModel,
   licenceCanProgress,
   formatDate,
+  daysSinceDate,
   canUpdateModel,
   canTransferPil,
-  numberWithCommas
+  numberWithCommas,
+  isDeadlineExtension
 };

--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -527,3 +527,8 @@ details {
     float: right;
   }
 }
+
+.deadline-passed {
+  color: $red;
+  margin-top: -$govuk-gutter-half;
+}

--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -136,10 +136,6 @@ dl.continuation {
   .declarations {
     p {
       margin: 0;
-
-      &.question {
-        margin-top: $govuk-gutter-half;
-      }
     }
   }
 }
@@ -520,8 +516,14 @@ details {
 
 #submitted-version {
   .declarations {
-    .question span {
-      font-weight: bold;
+    p {
+      margin: 0;
     }
+  }
+}
+
+.task-status {
+  .currently-with {
+    float: right;
   }
 }

--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -146,7 +146,7 @@ module.exports = {
       revocation: 'The revocation request will be sent to a Licensing Officer who will action your recommendation.',
       transfer: 'The transfer request will be sent to a Licensing Office who will action your recommendation'
     },
-    log: 'Recommended by',
+    log: 'Recommendation made by Inspector',
     recommendation: '**Recommendation:** Approve',
     currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },
@@ -159,7 +159,7 @@ module.exports = {
       revocation: 'The revocation request will be sent to a Licensing Officer who will action your recommendation.',
       transfer: 'The transfer request will be sent to a Licensing Officer who will action your recommendation.'
     },
-    log: 'Recommended by',
+    log: 'Recommendation made by Inspector',
     recommendation: '**Recommendation:**  Reject',
     currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },

--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -16,13 +16,13 @@ module.exports = {
   'with-licensing': {
     state: 'Awaiting decision',
     log: 'Submitted by',
-    currentlyWith: 'Currently with: Home Office Licensing Officer'
+    currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },
   'with-inspectorate': {
     state: 'Awaiting recommendation',
     action: 'Refer to inspector',
     log: 'Submitted by',
-    currentlyWith: 'Currently with: Home Office Inspector'
+    currentlyWith: '**Currently with:** Home Office Inspector'
   },
   'referred-to-inspector': {
     state: 'Awaiting recommendation',
@@ -34,7 +34,7 @@ module.exports = {
       transfer: 'The transfer request will be sent to an inspector for assessment.'
     },
     log: 'Referred by',
-    currentlyWith: 'Currently with: Home Office Inspector'
+    currentlyWith: '**Currently with:** Home Office Inspector'
   },
   'returned-to-applicant': {
     state: 'Returned',
@@ -47,7 +47,7 @@ module.exports = {
       review: 'The review request will be returned to the applicant with your comments.'
     },
     log: 'Returned by',
-    currentlyWith: 'Currently with: Applicant'
+    currentlyWith: '**Currently with:** Applicant'
   },
   'recalled-by-applicant': {
     state: 'Recalled',
@@ -62,7 +62,7 @@ module.exports = {
       default: 'The task will be returned and can be edited.'
     },
     log: 'Recalled by',
-    currentlyWith: 'Currently with: Applicant'
+    currentlyWith: '**Currently with:** Applicant'
   },
   'discarded-by-applicant': {
     state: 'Discarded',
@@ -101,7 +101,7 @@ module.exports = {
   'with-ntco': {
     state: 'Awaiting endorsement',
     log: 'Submitted by',
-    currentlyWith: 'Currently with: Named Training and Competency Officer'
+    currentlyWith: '**Currently with:** Named Training and Competency Officer'
   },
   'ntco-endorsed': {
     state: 'Awaiting decision',
@@ -116,15 +116,15 @@ module.exports = {
       transfer: 'You confirm that the applicant holds the necessary training or experience to carry out the categories of procedures listed in this transfer request.'
     },
     log: 'Endorsed by',
-    currentlyWith: 'Currently with: Home Office Licensing Officer'
+    currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },
   // TODO: content
   'awaiting-endorsement': {
     state: 'Awaiting endorsement',
     log: 'Submitted by',
     currentlyWith: {
-      pil: 'Currently with: Named Training and Competency Officer',
-      project: 'Currently with: Establishment Admin'
+      pil: '**Currently with:** Named Training and Competency Officer',
+      project: '**Currently with:** Establishment Admin'
     }
   },
   // TODO: content
@@ -148,7 +148,7 @@ module.exports = {
     },
     log: 'Recommended by',
     recommendation: '**Recommendation:** Approve',
-    currentlyWith: 'Currently with: Home Office Licensing Officer'
+    currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },
   'inspector-rejected': {
     state: 'Recommendation made',
@@ -161,7 +161,7 @@ module.exports = {
     },
     log: 'Recommended by',
     recommendation: '**Recommendation:**  Reject',
-    currentlyWith: 'Currently with: Home Office Licensing Officer'
+    currentlyWith: '**Currently with:** Home Office Licensing Officer'
   },
   resubmitted: {
     state: 'Submitted',

--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   'deadline-extended': {
     state: 'Deadline extended',
-    log: 'Extended by'
+    log: 'Deadline for decision extended by'
   },
   'with-licensing': {
     state: 'Awaiting decision',
@@ -220,7 +220,7 @@ module.exports = {
   },
   'deadline-extension': {
     state: 'Deadline extended',
-    log: 'Extended by'
+    log: 'Deadline for decision extended by'
   },
   updated: {
     state: 'Resubmitted',

--- a/pages/task/read/content/project.js
+++ b/pages/task/read/content/project.js
@@ -59,5 +59,9 @@ module.exports = {
       question: 'Has an inspector advised that this version of the draft application is ready for assessment?'
     }
   },
-  viewVersionLink: 'View this version ({{date}})'
+  viewVersionLink: 'View this version ({{date}})',
+  deadlineExtension: {
+    from: 'Deadline extended from: ',
+    to: 'Deadline extended to: '
+  }
 };

--- a/pages/task/read/content/project.js
+++ b/pages/task/read/content/project.js
@@ -64,6 +64,15 @@ module.exports = {
     extension: {
       from: 'Deadline extended from: ',
       to: 'Deadline extended to: '
+    },
+    today: '(Deadline is today)',
+    passed: {
+      singular: '(Deadline passed {{days}} day ago)',
+      plural: '(Deadline passed {{days}} days ago)'
+    },
+    lateDecision: {
+      singular: '{{days}} day over deadline for decision',
+      plural: '{{days}} days over deadline for decision'
     }
   }
 };

--- a/pages/task/read/content/project.js
+++ b/pages/task/read/content/project.js
@@ -34,8 +34,7 @@ module.exports = {
       info: 'Read the version of this project licence that is currently active'
     },
     submitted: {
-      label: 'View latest submission',
-      hint: 'This is the {{type}} that has been submitted for approval.'
+      label: 'View latest submission'
     }
   },
   establishment: {
@@ -46,22 +45,25 @@ module.exports = {
   },
   declarations: {
     'pel-holder': {
-      question: 'Does this application have the endorsement of your primary establishment\'s PEL holder?',
+      question: 'PEL holder approval:',
       name: 'PEL Holder:',
       'endorsement-date': 'Endorsement date: '
     },
     'awerb': {
-      question: 'Has the application been reviewed by the AWERB of each relevant establishment?',
+      question: 'AWERB approval:',
       'review-date': 'AWERB review date:',
-      'no-review-reason': 'Why has this amendment not been reviewed by the AWERB of each relevant establishment?'
+      'no-review-reason': 'Reason for no review:'
     },
     'ready-for-inspector': {
-      question: 'Has an inspector advised that this version of the draft application is ready for assessment?'
+      question: 'Inspector approval:'
     }
   },
   viewVersionLink: 'View this version ({{date}})',
-  deadlineExtension: {
-    from: 'Deadline extended from: ',
-    to: 'Deadline extended to: '
+  deadline: {
+    title: 'Deadline for decision: ',
+    extension: {
+      from: 'Deadline extended from: ',
+      to: 'Deadline extended to: '
+    }
   }
 };

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -50,10 +50,10 @@ function DeadlineDetails({ item }) {
   return (
     <Fragment>
       <p>
-        <strong><Snippet>deadlineExtension.from</Snippet></strong> <span>{format(standardDeadline, dateFormat.long)}</span>
+        <strong><Snippet>deadline.extension.from</Snippet></strong> <span>{format(standardDeadline, dateFormat.long)}</span>
       </p>
       <p>
-        <strong><Snippet>deadlineExtension.to</Snippet></strong> <span>{format(extendedDeadline, dateFormat.long)}</span>
+        <strong><Snippet>deadline.extension.to</Snippet></strong> <span>{format(extendedDeadline, dateFormat.long)}</span>
       </p>
     </Fragment>
   );

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -39,6 +39,15 @@ const actionPerformedByAdmin = item => {
   return !!profile.establishments.find(e => e.id === establishmentId && e.role === 'admin');
 };
 
+function DeadlineDetails({ item, task }) {
+  return (
+    <Fragment>
+      <p><strong><Snippet>deadlineExtension.from</Snippet></strong><span>{item.originalDeadline}</span></p>
+      <p><strong><Snippet>deadlineExtension.to</Snippet></strong><span>{item.deadline}</span></p>
+    </Fragment>
+  );
+}
+
 function ExtraProjectMeta({ item, task }) {
   const mostRecentActivity = item.id === task.activityLog[0].id;
   const versionId = get(item, 'event.data.data.version');
@@ -96,6 +105,7 @@ function LogItem({ log, task }) {
       <span className="date">{format(log.createdAt, dateFormat.long)}</span>
       <Action task={task} action={action} changedBy={log.changedBy} />
       <InspectorRecommendation status={status} />
+      { isExtension && <DeadlineDetails item={log} /> }
       <Comment changedBy={log.changedBy} comment={log.comment} />
       { task.data.model === 'project' && <ExtraProjectMeta item={log} task={task} /> }
     </div>

--- a/pages/task/read/views/components/deadline.jsx
+++ b/pages/task/read/views/components/deadline.jsx
@@ -1,35 +1,31 @@
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-import { Link, Snippet } from '@asl/components';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import get from 'lodash/get';
+import { Link, Snippet, Details } from '@asl/components';
 import { dateFormat } from '../../../../../constants';
 import { formatDate } from '../../../../../lib/utils';
 
-class Deadline extends Component {
-  render() {
-    const task = this.props.task;
+export default function Deadline({ task }) {
+  const isInspector = useSelector(state => state.static.isInspector);
+  const isExtended = get(task, 'data.deadline.isExtended', false);
+  const deadline = get(task, 'data.deadline');
+  const deadlineDate = get(deadline, isExtended ? 'extended' : 'standard');
 
-    return (
-      <div className="deadline">
-        <h2><Snippet>sticky-nav.deadline</Snippet></h2>
+  return (
+    <div className="deadline">
+      <h3>Statutory deadline: { deadlineDate ? formatDate(deadlineDate, dateFormat.long) : 'Not yet set' }</h3>
 
-        <h3>{ formatDate(task.deadline, dateFormat.long) }</h3>
-
-        { this.props.isInspector && task.isExtendable &&
-          <Fragment>
-            <p><Snippet>deadline.hint</Snippet></p>
-            <Link
-              page="task.read.extend"
-              taskId={task.id}
-              label={<Snippet>deadline.extend.button</Snippet>}
-              className="govuk-button button-secondary"
-            />
-          </Fragment>
-        }
-      </div>
-    );
-  }
+      { isInspector && deadline && deadline.isExtendable &&
+        <Details summary="Extend deadline">
+          <p><Snippet>deadline.hint</Snippet></p>
+          <Link
+            page="task.read.extend"
+            taskId={task.id}
+            label={<Snippet>deadline.extend.button</Snippet>}
+            className="govuk-button button-secondary"
+          />
+        </Details>
+      }
+    </div>
+  );
 }
-
-const mapStateToProps = ({ static: { isInspector } }) => ({ isInspector });
-
-export default connect(mapStateToProps)(Deadline);

--- a/pages/task/read/views/components/deadline.jsx
+++ b/pages/task/read/views/components/deadline.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import { Link, Snippet, Details } from '@asl/components';
 import { dateFormat } from '../../../../../constants';
-import { formatDate } from '../../../../../lib/utils';
+import { formatDate, daysSinceDate } from '../../../../../lib/utils';
 
 export default function Deadline({ task }) {
   const isInspector = useSelector(state => state.static.isInspector);
@@ -15,9 +15,24 @@ export default function Deadline({ task }) {
     return null;
   }
 
+  const daysSinceDeadline = daysSinceDate(deadlineDate); // will be negative until deadline day
+
   return (
     <div className="deadline">
       <h3><Snippet>deadline.title</Snippet> {formatDate(deadlineDate, dateFormat.long)}</h3>
+
+      {
+        daysSinceDeadline >= 0 &&
+          <p className="deadline-passed">
+            {
+              daysSinceDeadline === 0 && <Snippet>deadline.today</Snippet>
+            }
+            {
+              daysSinceDeadline > 0 &&
+                <Snippet days={daysSinceDeadline}>{`deadline.passed.${daysSinceDeadline > 1 ? 'plural' : 'singular'}`}</Snippet>
+            }
+          </p>
+      }
 
       { isInspector && deadline && deadline.isExtendable &&
         <Details summary="Extend deadline">

--- a/pages/task/read/views/components/deadline.jsx
+++ b/pages/task/read/views/components/deadline.jsx
@@ -11,9 +11,13 @@ export default function Deadline({ task }) {
   const deadline = get(task, 'data.deadline');
   const deadlineDate = get(deadline, isExtended ? 'extended' : 'standard');
 
+  if (!deadlineDate) {
+    return null;
+  }
+
   return (
     <div className="deadline">
-      <h3>Statutory deadline: { deadlineDate ? formatDate(deadlineDate, dateFormat.long) : 'Not yet set' }</h3>
+      <h3><Snippet>deadline.title</Snippet> {formatDate(deadlineDate, dateFormat.long)}</h3>
 
       { isInspector && deadline && deadline.isExtendable &&
         <Details summary="Extend deadline">

--- a/pages/task/read/views/components/ppl-declarations.jsx
+++ b/pages/task/read/views/components/ppl-declarations.jsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import isUndefined from 'lodash/isUndefined';
 import { Markdown, Snippet } from '@asl/components';
 
 // declarations can be 'Yes', 'No', or 'Not yet'
@@ -16,15 +15,12 @@ export default function PplDeclarations({ task }) {
 
   return (
     <div className="declarations">
-      <p className="question"><Snippet>declarations.pel-holder.question</Snippet></p>
-      <p>{declarations.authority || 'No'}</p>
-
-      <p className="question"><Snippet>declarations.awerb.question</Snippet></p>
-      <p>{declarations.awerb}</p>
+      <p><strong><Snippet>declarations.pel-holder.question</Snippet></strong> {declarations.authority || 'No'}</p>
+      <p><strong><Snippet>declarations.awerb.question</Snippet></strong> {declarations.awerb}</p>
       {
         declarationConfirmed(declarations.awerb) &&
           <Fragment>
-            <p className="question"><Snippet>declarations.awerb.review-date</Snippet></p>
+            <p><strong><Snippet>declarations.awerb.review-date</Snippet></strong></p>
             <Markdown>{declarations['awerb-review-date']}</Markdown>
           </Fragment>
       }
@@ -32,17 +28,13 @@ export default function PplDeclarations({ task }) {
         // we don't collect a reason for 'Not yet'
         declarations.awerb && declarations.awerb.toLowerCase() === 'no' &&
           <Fragment>
-            <p className="question"><Snippet>declarations.awerb.no-review-reason</Snippet></p>
+            <p><strong><Snippet>declarations.awerb.no-review-reason</Snippet></strong></p>
             <Markdown>{declarations['awerb-no-review-reason']}</Markdown>
           </Fragment>
       }
-
       {
-        !isAmendment && !isUndefined(declarations.ready) &&
-          <Fragment>
-            <p className="question"><Snippet>declarations.ready-for-inspector.question</Snippet></p>
-            <p>{declarations.ready}</p>
-          </Fragment>
+        !isAmendment &&
+          <p><strong><Snippet>declarations.ready-for-inspector.question</Snippet></strong> {declarations.ready || 'No'}</p>
       }
     </div>
   );

--- a/pages/task/read/views/components/task-status.jsx
+++ b/pages/task/read/views/components/task-status.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import get from 'lodash/get';
 import classnames from 'classnames';
 import { Snippet } from '@asl/components';
+import Deadline from './deadline';
 
 const getStatusBadge = status => {
   const good = ['resolved'];
@@ -14,13 +15,15 @@ const getStatusBadge = status => {
 export default function TaskStatus({ task }) {
   const model = get(task, 'data.model');
   const latestActivity = task.activityLog[0];
-
-  const isExtension = get(latestActivity, 'event.meta.payload.data.extended');
   let { action, status } = latestActivity;
 
-  if (action === 'update' && isExtension) {
-    status = 'deadline-extended';
-    action = 'deadline-extended';
+  if (model === 'project') {
+    const isExtension = get(latestActivity, 'event.data.deadline.isExtended') || get(latestActivity, 'event.meta.payload.data.extended', false);
+
+    if (action === 'update' && isExtension) {
+      status = 'with-inspectorate';
+      action = 'with-inspectorate';
+    }
   }
 
   let snippetContent = `status.${status}.currentlyWith`;
@@ -34,6 +37,7 @@ export default function TaskStatus({ task }) {
       <h2><Snippet>sticky-nav.status</Snippet></h2>
       {getStatusBadge(status)}
       <p><Snippet optional>{snippetContent}</Snippet></p>
+      { model === 'project' && <Deadline task={task} /> }
     </div>
   );
 }

--- a/pages/task/read/views/components/task-status.jsx
+++ b/pages/task/read/views/components/task-status.jsx
@@ -8,8 +8,7 @@ const getStatusBadge = status => {
   const good = ['resolved'];
   const bad = ['rejected', 'withdrawn'];
   const className = classnames({ badge: true, complete: good.includes(status), rejected: bad.includes(status) });
-
-  return <p><span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span></p>;
+  return <span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span>;
 };
 
 export default function TaskStatus({ task }) {
@@ -35,8 +34,10 @@ export default function TaskStatus({ task }) {
   return (
     <div className="task-status">
       <h2><Snippet>sticky-nav.status</Snippet></h2>
-      {getStatusBadge(status)}
-      <p><Snippet optional>{snippetContent}</Snippet></p>
+      <p>
+        {getStatusBadge(status)}
+        <span className="currently-with"><Snippet optional>{snippetContent}</Snippet></span>
+      </p>
       { model === 'project' && <Deadline task={task} /> }
     </div>
   );

--- a/pages/task/read/views/components/task-status.jsx
+++ b/pages/task/read/views/components/task-status.jsx
@@ -3,6 +3,7 @@ import get from 'lodash/get';
 import classnames from 'classnames';
 import { Snippet } from '@asl/components';
 import Deadline from './deadline';
+import { isDeadlineExtension } from '../../../../../lib/utils';
 
 const getStatusBadge = status => {
   const good = ['resolved'];
@@ -17,7 +18,7 @@ export default function TaskStatus({ task }) {
   let { action, status } = latestActivity;
 
   if (model === 'project') {
-    const isExtension = get(latestActivity, 'event.data.deadline.isExtended') || get(latestActivity, 'event.meta.payload.data.extended', false);
+    const isExtension = isDeadlineExtension(latestActivity);
 
     if (action === 'update' && isExtension) {
       status = 'with-inspectorate';

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -9,7 +9,6 @@ import { Link, StickyNavAnchor, Snippet, Diff } from '@asl/components';
 import { ReviewFields } from '@asl/projects/client/components/review-fields';
 import format from 'date-fns/format';
 import { dateFormat } from '../../../../../constants';
-import Deadline from '../components/deadline';
 import PplDeclarations from '../components/ppl-declarations';
 import experience from '../../../../project/update-licence-holder/schema/experience-fields';
 import { schema as projectSchema } from '../../../../project/schema';
@@ -49,7 +48,7 @@ function EstablishmentDiff({ task }) {
   );
 }
 
-export default function Project({ task, schema }) {
+export default function Project({ task }) {
   const { project, establishment, version, values } = useSelector(selector, shallowEqual);
   const declarations = task.data.meta;
   const continuation = task.data.continuation;
@@ -174,14 +173,6 @@ export default function Project({ task, schema }) {
               </Fragment>
             )
           }
-        </StickyNavAnchor>
-      )
-    ),
-
-    (
-      task.deadline && (
-        <StickyNavAnchor id="deadline" key="deadline">
-          <Deadline task={task} />
         </StickyNavAnchor>
       )
     ),

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -50,12 +50,10 @@ function EstablishmentDiff({ task }) {
 
 export default function Project({ task }) {
   const { project, establishment, version, values } = useSelector(selector, shallowEqual);
-  const declarations = task.data.meta;
   const continuation = task.data.continuation;
   const continuationRTE = get(version, 'data.expiring-yes');
 
   const isComplete = !task.isOpen;
-  const showDeclarations = declarations.authority || declarations.awerb;
 
   const formatters = {
     licenceHolder: {
@@ -109,7 +107,9 @@ export default function Project({ task }) {
       (task.data.action === 'grant' || task.data.action === 'transfer') && (
         <StickyNavAnchor id="submitted-version" key="submitted-version">
           <h2><Snippet>sticky-nav.submitted-version</Snippet></h2>
-          <p><Snippet type={task.type}>versions.submitted.hint</Snippet></p>
+          {
+            task.status === 'with-inspectorate' && <PplDeclarations task={task} />
+          }
           <p>
             <Link
               page="projectVersion"
@@ -120,10 +120,6 @@ export default function Project({ task }) {
               label={<Snippet>versions.submitted.label</Snippet>}
             />
           </p>
-          {
-            task.status === 'with-inspectorate' && showDeclarations &&
-              <PplDeclarations task={task} />
-          }
         </StickyNavAnchor>
       )
     ),


### PR DESCRIPTION
 * Moves the deadline to the top of the page in the status section
 * Deadline before/after will display in the activity log for deadline extension activity
 * Deadline passed warning on both of the above when applicable
 * AWERB / ready / authority playback was simplified