### PR TITLE
Don't copy complete project data to req.model

### DIFF
--- a/pages/project-version/update/submit/index.js
+++ b/pages/project-version/update/submit/index.js
@@ -46,7 +46,10 @@ module.exports = settings => {
   });
 
   app.use((req, res, next) => {
-    req.model = req.version;
+    req.model = {
+      ...req.version,
+      data: pick(req.version.data, 'title')
+    };
     next();
   });
 


### PR DESCRIPTION
The version data is not used to render the form, and results in multiple copies of the data property being held in memory inside the form router.

For large PPL data blobs this results in OOM errors. By removing all except the title - which is used to render the page - from the data blob then the memory usage of the page render is reduced by ~99%.