### PR TITLE
Remove redundant copy of `req.version`

### DIFF
--- a/pages/project-version/update/success/index.js
+++ b/pages/project-version/update/success/index.js
@@ -7,11 +7,6 @@ module.exports = settings => {
     root: __dirname
   });
 
-  app.use((req, res, next) => {
-    req.model = req.version;
-    next();
-  });
-
   app.use(success());
 
   app.use((req, res, next) => res.sendResponse());


### PR DESCRIPTION
`req.model` isn't used downstream anywhere, so it's just using memory for no reason.