### PR TITLE
Ensure lists are ordered in a stable way

### DIFF
--- a/pages/establishment/dashboard/views/index.jsx
+++ b/pages/establishment/dashboard/views/index.jsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
+import sortBy from 'lodash/sortBy';
 import {
   Snippet,
   Link,
@@ -50,8 +51,9 @@ const Index = ({
   allowedActions,
   asruAdmin
 }) => {
-  const inspectors = establishment.asru.filter(p => p.asruUser && p.asruInspector);
-  const spocs = establishment.asru.filter(p => p.asruUser && p.asruLicensing);
+  const inspectors = sortBy(establishment.asru.filter(p => p.asruUser && p.asruInspector), 'lastName');
+  const spocs = sortBy(establishment.asru.filter(p => p.asruUser && p.asruLicensing), 'lastName');
+  const holcs = sortBy(establishment.holc, 'lastName');
   const openApplication = allowedActions.includes('establishment.update') && establishment.openTasks.find(task => task.data && task.data.model === 'establishment' && task.data.action === 'grant');
   const canApply = establishment.status !== 'active' && allowedActions.includes('establishment.update') && !openApplication;
 
@@ -90,12 +92,12 @@ const Index = ({
             }
 
             {
-              !!establishment.holc.length &&
+              !!holcs.length &&
                 <Fragment>
                   <dt><Snippet>holc</Snippet></dt>
                   <dd>
                     {
-                      establishment.holc.map(holc => (
+                      holcs.map(holc => (
                         <p key={holc.id} className="holc">
                           <Link page="profile.read" profileId={holc.profile.id} label={`${holc.profile.firstName} ${holc.profile.lastName}`} />
                         </p>

--- a/pages/profile/list/views/index.jsx
+++ b/pages/profile/list/views/index.jsx
@@ -30,7 +30,7 @@ export const peopleFormatters = {
     format: (name, person) => <Link page="profile.read" profileId={person.id} label={`${person.firstName} ${person.lastName}`} />
   },
   roles: {
-    accessor: row => row.roles && row.roles.map(v => v.type),
+    accessor: row => row.roles && row.roles.map(v => v.type).sort(),
     format: data => data && joinAcronyms(data.map(selectivelyUppercase))
   },
   pilLicenceNumber: {


### PR DESCRIPTION
List of users and roles in the establishment sidebar and people lists are sorted in an arbitrary way which means they keep throwing false-positives in regression tests.

Apply a sort to these cases to ensure that they are always ordered consistently.