### PR TITLE
Handle case where NACWO cannot be found

### DIFF
--- a/pages/task/read/routers/read.js
+++ b/pages/task/read/routers/read.js
@@ -191,7 +191,9 @@ module.exports = () => {
 
       if (nacwoProfileId) {
         const nacwoRole = req.establishment.nacwo.find(r => r.profile.id === nacwoProfileId);
-        roleIds.push(nacwoRole.id);
+        if (nacwoRole) {
+          roleIds.push(nacwoRole.id);
+        }
       }
 
       const allNacwos = req.establishment.nacwo;


### PR DESCRIPTION
We think this is where a nacwo is assigned to a place with a task related to it, but has since had the nacwo role removed.