### PR TITLE
Add middleware to dynamically load selected permissions into `allowedActions`

### DIFF
--- a/pages/common/middleware/load-permissions.js
+++ b/pages/common/middleware/load-permissions.js
@@ -1,0 +1,27 @@
+const { every } = require('lodash');
+/*
+ * check a set of permission tasks based on the request params
+ * and add any that match to `allowedActions`
+ */
+
+module.exports = (...perms) => (req, res, next) => {
+  if (Array.isArray(perms[0])) {
+    perms = perms[0];
+  }
+
+  // continue immediately if user has all permissions already
+  if (every(perms, p => res.locals.static.allowedActions.includes(p))) {
+    return next();
+  }
+
+  Promise.all(perms.map(p => req.user.can(p, req.params)))
+    .then(result => {
+      perms.forEach((p, i) => {
+        if (result[i]) {
+          res.locals.static.allowedActions.push(p);
+        }
+      });
+    })
+    .then(() => next())
+    .catch(next);
+};

--- a/pages/profile/read/index.js
+++ b/pages/profile/read/index.js
@@ -1,5 +1,6 @@
 const { page } = require('@asl/service/ui');
 const { relatedTasks } = require('../../common/routers');
+const loadPermissions = require('../../common/middleware/load-permissions');
 
 module.exports = settings => {
   const app = page({
@@ -11,6 +12,8 @@ module.exports = settings => {
     res.locals.static.isOwnProfile = req.user.profile.id === req.profileId;
     next();
   });
+
+  app.get('/', loadPermissions('training.read', 'training.update'));
 
   app.get('/', relatedTasks(req => {
     return {


### PR DESCRIPTION
By default `allowedActions` only includes tasks that a user can _always_ perform, and does not include permissions which vary depending on the exact entity being viewed.

The `loadPermissions` middleware allows a selection of tasks to be dynamically loaded into `allowedActions` based on the current request params.

In this particular case it adds the training permissions to profiles, which for non-admin users is dependent on whether they are viewing their own profile or not.