### PR TITLE
Restore correct headings to billing pages

### DIFF
--- a/pages/establishment/licence-fees/content/index.js
+++ b/pages/establishment/licence-fees/content/index.js
@@ -1,9 +1,9 @@
 module.exports = {
-  title: 'Estimated licence fees',
   notifications: {
     'fee-waived-updated': 'Updated billable status'
   },
   fees: {
+    title: 'Estimated licence fees',
     period: 'Covering the period:',
     disclaimer: 'These projections are based on the number of billable licences held and may differ from the final numbers.',
     details: {

--- a/pages/establishment/licence-fees/index.js
+++ b/pages/establishment/licence-fees/index.js
@@ -11,7 +11,7 @@ module.exports = settings => {
   });
 
   app.use((req, res, next) => {
-    res.locals.pageTitle = `${res.locals.static.content.title} - ${req.establishment.name}`;
+    res.locals.pageTitle = `${res.locals.static.content.fees.title} - ${req.establishment.name}`;
     next();
   });
 

--- a/pages/establishment/licence-fees/views/index.jsx
+++ b/pages/establishment/licence-fees/views/index.jsx
@@ -81,7 +81,7 @@ export default function Fees({ tab, tabs, children, subtitle = '' }) {
       <WidthContainer>
         <ErrorSummary />
         <Header
-          title={<Snippet>title</Snippet>}
+          title={<Snippet>fees.title</Snippet>}
           subtitle={establishment ? establishment.name : subtitle}
         />
         <div className="subtitle">


### PR DESCRIPTION
The top-level `title` property was already being used, so this needs to go back to how it was before to keep the correct page h1 heading.