### PR TITLE
Prevent inherited place content overwriting title

### DIFF
--- a/pages/task/read/content/place.js
+++ b/pages/task/read/content/place.js
@@ -2,6 +2,9 @@ const { merge } = require('lodash');
 const place = require('../../../place/content');
 
 module.exports = merge({}, place, {
+  title: {
+    /* overwrites title property from place content with an emptyobject for a safe merge */
+  },
   'sticky-nav': {
     details: 'Establishment details',
     create: 'Approved area to add',


### PR DESCRIPTION
The task base content has `title` as an object with several properties defined. Inheriting the string `title` property from place content overwrote this and prevented the correct title from being available.

By setting the title property for place-specific content with an empty object the string is no longer merged onto the object and the default title properties are preserved.