### PR TITLE
Load content for page title

### DIFF
--- a/pages/establishment/licence-fees/index.js
+++ b/pages/establishment/licence-fees/index.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const routes = require('./routes');
+const content = require('./content');
 
 module.exports = settings => {
   const app = Router({ mergeParams: true });
@@ -11,7 +12,7 @@ module.exports = settings => {
   });
 
   app.use((req, res, next) => {
-    res.locals.pageTitle = `${res.locals.static.content.fees.title} - ${req.establishment.name}`;
+    res.locals.pageTitle = `${content.fees.title} - ${req.establishment.name}`;
     next();
   });
 


### PR DESCRIPTION
This router doesn't mount a page router, and so doesn't load local content onto res.locals.

Go fetch the content manually instead.