### PR TITLE
Normalise PIL procedures

### DIFF
--- a/pages/pil/dashboard/views/index.jsx
+++ b/pages/pil/dashboard/views/index.jsx
@@ -49,11 +49,10 @@ const Index = ({
   canTransferPil,
   trainingUpToDate
 }) => {
-
   const taskType = model.status === 'pending' ? 'application' : 'amendment';
 
-  const beforeProcs = pil.procedures.map(p => ({ key: p }));
-  const afterProcs = model.procedures.map(p => ({ key: p }));
+  const beforeProcs = pil.procedures.map(p => (p.key ? p : { key: p }));
+  const afterProcs = model.procedures.map(p => (p.key ? p : { key: p }));
 
   const sections = [
     {


### PR DESCRIPTION
The API response has different structure for procedures depending on whether it was loaded from `/pil` or `/pil/:id`. Modify this code to leave the procedures intact if they already have a `key` property set. This then supports procedures in either structure.