### PR TITLE
Restore setting of req.model = req.pil

### DIFF
--- a/pages/pil/index.js
+++ b/pages/pil/index.js
@@ -10,6 +10,7 @@ module.exports = settings => {
         req.pilId = pilId;
         req.pil = response.json.data;
         req.pil.openTasks = response.json.meta.openTasks;
+        req.model = req.pil;
         next();
       })
       .catch(next);


### PR DESCRIPTION
Inside the `pilId` param call `req.pil` is the specifically scoped "normal" PIL, as opposed to the aggregated PIL model which is set to `req.model` further down.

This needs to set `req.model` so that it is pointing at the "normal" PIL in contexts where that is being acted on.