### PR TITLE
Don't throw error if PIL API request fails with 404

### DIFF
--- a/pages/profile/read/index.js
+++ b/pages/profile/read/index.js
@@ -28,7 +28,13 @@ module.exports = settings => {
         res.locals.static.profile.pil = req.pil;
         next();
       })
-      .catch(next);
+      .catch(e => {
+        if (e.status === 404) {
+          req.pil = null;
+          return next();
+        }
+        next(e);
+      });
   });
 
   app.get('/', relatedTasks(req => {


### PR DESCRIPTION
If viewing a profile as a basic user then you won't have permission to view the PIL. Don't 404 the entire profile if the PIL request returns a 404.