### PR TITLE
Redirect from /pil/:id to /pil

### DIFF
--- a/pages/pil/read/index.js
+++ b/pages/pil/read/index.js
@@ -98,6 +98,9 @@ module.exports = settings => {
     res.redirect(req.buildRoute('pil.read'));
   });
 
+  // redirect old /pil/:pilId links
+  app.get('/:pilId', (req, res) => res.redirect(req.buildRoute('pil.read')));
+
   app.get('/', (req, res) => res.sendResponse());
 
   return app;


### PR DESCRIPTION
The URL to view a PIL has moved from `/pil/:id` to `/pil`. Redirect any users trying to access old urls to the new url.