### PR TITLE
Explain why the change ppl holder action is missing

### DIFF
--- a/pages/project/read/content/index.js
+++ b/pages/project/read/content/index.js
@@ -76,7 +76,8 @@ module.exports = merge({}, baseContent, {
       amendment: 'Discard this amendment',
       stub: 'Cancel licence conversion'
     },
-    amendStub: 'Edit record'
+    amendStub: 'Edit record',
+    cantChangeHolder: 'An amendment is in progress so the PPL holder cannot be changed'
   },
   confirm: {
     application: 'Are you sure you want to discard this draft project?',

--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -368,7 +368,7 @@ export default function ProjectLandingPage() {
   const isEditable = model.status === 'active' || model.status === 'inactive';
   const grantedVersion = model.versions.find(v => v.status === 'granted');
 
-  const canChangeLicenceHolder = canUpdate && !openTask && isEditable && (!model.isLegacyStub || (model.isLegacyStub && asruLicensing));
+  const canChangeLicenceHolder = canUpdate && isEditable && (!model.isLegacyStub || (model.isLegacyStub && asruLicensing));
 
   return (
     <Fragment>
@@ -387,7 +387,12 @@ export default function ProjectLandingPage() {
           <Link page="profile.read" profileId={model.licenceHolder.id} label="View profile" />
           {
             canChangeLicenceHolder && (
-              <Fragment> | <Link page="project.updateLicenceHolder" label="Change" /></Fragment>
+              <Fragment> | {
+                openTask
+                  ? <Snippet>actions.cantChangeHolder</Snippet>
+                  : <Link page="project.updateLicenceHolder" label="Change" />
+              }
+              </Fragment>
             )
           }
         </dd>


### PR DESCRIPTION
Users are prevented from changing PPL holder while there are open tasks. Show a reason why instead of just hiding the link.