### PR TITLE
Bugfix - conditions border overlap

### DIFF
--- a/pages/common/assets/sass/pdf/index.scss
+++ b/pages/common/assets/sass/pdf/index.scss
@@ -150,6 +150,10 @@ dl dd {
   font-size: 15px !important;
 }
 
+.conditions .condition {
+  page-break-inside: avoid !important;
+}
+
 .granted-page.action-plan {
   > h3:first-of-type {
     display: none;


### PR DESCRIPTION
* Because of the way table headers are rendered in pdfs, conditions spanning multiple pages render with a streteched border overlapping the table header - avoid page break in a condition