### PR TITLE
Fix sorting PILs by licence number

### DIFF
--- a/pages/pil/unscoped/list/schema/index.js
+++ b/pages/pil/unscoped/list/schema/index.js
@@ -5,7 +5,8 @@ module.exports = {
     sort: 'profile.lastName'
   },
   licenceNumber: {
-    show: true
+    show: true,
+    sort: 'profile.pilLicenceNumber'
   },
   issueDate: {
     show: true


### PR DESCRIPTION
Licence numbers are stored on a profile now, so the sort property on that column needs to be defined as that or it fails out.