### PR TITLE
Restore two-thirds wrapper to PIL declarations

### DIFF
--- a/pages/pil/dashboard/views/index.jsx
+++ b/pages/pil/dashboard/views/index.jsx
@@ -102,7 +102,11 @@ const Index = ({
       />
       <p><Snippet>pil.summary</Snippet></p>
       <SectionList sections={sections.map(s => ({ ...s, Component: SectionDetails }))} />
-      <Form />
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <Form />
+        </div>
+      </div>
       {
         model.status === 'pending' && (
           <form


### PR DESCRIPTION
These were lost with this commit - https://github.com/UKHomeOffice/asl-pages/commit/4830e73a239262c62edfb10eb292a3a026bc1285#diff-94db34bb992d2c29c037feb2a25fc9864a6c43875ad1b1045450989642ad73cfL30-L31