### PR TITLE
Fix sorting billable PILs

### DIFF
--- a/pages/establishment/licence-fees/personal/schema/index.js
+++ b/pages/establishment/licence-fees/personal/schema/index.js
@@ -6,7 +6,8 @@ module.exports = req => {
       toCSVString: (_, row) => `${row.profile.firstName} ${row.profile.lastName}`
     },
     licenceNumber: {
-      show: true
+      show: true,
+      sort: 'pilLicenceNumber'
     },
     startDate: {
       show: true,


### PR DESCRIPTION
Sort poperty needs to be `pilLicenceNumber` because that is the name fo the property on a profile.