### PR TITLE
Clone schema in form configuration

### DIFF
--- a/pages/common/routers/form.js
+++ b/pages/common/routers/form.js
@@ -15,7 +15,8 @@ const {
   omit,
   chain,
   reduce,
-  castArray
+  castArray,
+  cloneDeep
 } = require('lodash');
 const validator = require('../../../lib/validation');
 const { hasChanged, cleanModel } = require('../../../lib/utils');
@@ -137,7 +138,7 @@ module.exports = ({
 
   const _configure = (req, res, next) => {
     req.form = req.form || {};
-    req.form.schema = schema;
+    req.form.schema = cloneDeep(schema);
     req.session.form = req.session.form || {};
     req.session.form[req.model.id] = req.session.form[req.model.id] || {};
     req.session.form[req.model.id].values = req.session.form[req.model.id].values || {};


### PR DESCRIPTION
This prevents any unintended side-effects of setting properties on the schema during the request pipeline being persisted in the global state.