### PR TITLE
Don't allow editing a version that is not the most recent

### DIFF
--- a/pages/project-version/update/index.js
+++ b/pages/project-version/update/index.js
@@ -33,6 +33,9 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     //move users away from edit route if not viewing a draft
+    if (req.version.id !== req.project.draft.id) {
+      return res.redirect(req.buildRoute('projectVersion.update', { versionId: req.project.draft.id }));
+    }
     if (req.version.status !== 'draft') {
       return res.redirect(req.buildRoute('projectVersion.read'));
     }


### PR DESCRIPTION
If a user has submitted an application for endorsement which has then been returned then it will still have a status of draft, this prevents the user from editing that version and bumps them to the editable version.