### PR TITLE
Check draft exists when comparing ids

### DIFF
--- a/pages/project-version/update/index.js
+++ b/pages/project-version/update/index.js
@@ -33,7 +33,7 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     //move users away from edit route if not viewing a draft
-    if (req.version.id !== req.project.draft.id) {
+    if (req.project.draft && req.version.id !== req.project.draft.id) {
       return res.redirect(req.buildRoute('projectVersion.update', { versionId: req.project.draft.id }));
     }
     if (req.version.status !== 'draft') {


### PR DESCRIPTION
If there is no draft version then this throws an error. This occurs when a user has bookmarked the edit page of an application, which is then granted.