### PR TITLE
Don't allow edits to project versions if there is an open task

### DIFF
--- a/pages/project-version/update/index.js
+++ b/pages/project-version/update/index.js
@@ -32,12 +32,18 @@ module.exports = settings => {
   app.use('/success', success());
 
   app.use((req, res, next) => {
-    //move users away from edit route if not viewing a draft
-    if (req.project.draft && req.version.id !== req.project.draft.id) {
-      return res.redirect(req.buildRoute('projectVersion.update', { versionId: req.project.draft.id }));
+    // move users to read only route if there is a non-editable open task
+    if (req.project.openTasks && req.project.openTasks[0].editable === false) {
+      return res.redirect(req.buildRoute('projectVersion.read'));
     }
+    // move users away from edit route if not viewing a draft
     if (req.version.status !== 'draft') {
       return res.redirect(req.buildRoute('projectVersion.read'));
+    }
+    // if this is not the latest draft (i.e. this version was returned by admin without endorsing)
+    // then redirect to edit view of latest draft
+    if (req.project.draft && req.version.id !== req.project.draft.id) {
+      return res.redirect(req.buildRoute('projectVersion.update', { versionId: req.project.draft.id }));
     }
     next();
   });


### PR DESCRIPTION
If a draft has been submitted to the PEL holder delegate for approval, but has not yet been submitted to ASRU then it has a status of `draft` however it should no longer be editable at this point.

Check if there is an open task for the project and if the task is not editable then redirect to the read-only route of the project version.