### PR TITLE
Show changes correctly for establishment fields

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -98,6 +98,11 @@ const getNode = (tree, path) => {
   if (path === 'reduction-quantities') {
     return mapAnimalQuantities(tree, 'reduction-quantities');
   }
+  if (path.match(/establishments\.(.*)\.establishment-id/)) {
+    const id = path.split('.')[1];
+    const establishment = (tree.establishments || []).find(e => e.id === id);
+    return establishment && (establishment.name || establishment['establishment-name']);
+  }
   let keys = path.split('.');
   let node = tree[keys[0]];
   for (let i = 1; i < keys.length; i++) {


### PR DESCRIPTION
Where an additional establishment on a PPL has changed get the name correctly independently of whether it was added as a data link by id, or using a free text input.

This means that the old values display correctly in comparison windows and changed indicators show as appropriate.