### PR TITLE
Prevent removal of permissions from AA PPL holders

### DIFF
--- a/pages/profile/permission/index.js
+++ b/pages/profile/permission/index.js
@@ -22,8 +22,16 @@ module.exports = settings => {
   app.use('/', (req, res, next) => {
     const hasRoles = some(req.profile.roles, role => role.establishmentId === req.establishmentId);
     const hasPil = req.profile.pil && req.profile.pil.status === 'active' && req.profile.pil.establishmentId === req.establishmentId;
-    const hasProjects = some(req.profile.projects, project => project.status === 'active' && project.establishmentId === req.establishmentId);
-    res.locals.static.isNamed = !!hasRoles || !!hasPil || !!hasProjects;
+
+    const hasProjects = some(req.profile.projects, project => {
+      return project.status === 'active' && project.establishmentId === req.establishmentId;
+    });
+
+    const hasAdditionalProjects = some(req.profile.projects, project => {
+      return project.status === 'active' && project.additionalEstablishments.map(est => est.id).includes(req.establishmentId);
+    });
+
+    res.locals.static.isNamed = !!hasRoles || !!hasPil || !!hasProjects || !!hasAdditionalProjects;
     next();
   });
 


### PR DESCRIPTION
If a person holds a PPL with an additional availability at an establishment then they should not be able to have permissions removed.