### PR TITLE
Set datatable CSV download limit to 10,000

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -85,7 +85,7 @@ module.exports = ({
     }
     let { rows = defaultRowCount, page } = req.query;
     if (req.query.csv) {
-      rows = 1e6;
+      rows = 1e4;
       page = 1;
     }
     page = parseInt(page, 10) - 1 || 0;


### PR DESCRIPTION
This is the maximum number of rows that elastic will allow by default, and it throws an error if more are requested.

Since no table that uses the CSV export has more than 10,000 rows this should be fine.