### PR TITLE
Add PIL E field labels to PIL amendment dashboard

### DIFF
--- a/pages/pil/dashboard/content/index.js
+++ b/pages/pil/dashboard/content/index.js
@@ -2,6 +2,7 @@ const { merge } = require('lodash');
 const baseContent = require('../../content');
 const procedures = require('../../procedures/content');
 const species = require('../../species/content');
+const trainingFields = require('../../unscoped/courses/content/fields');
 
 module.exports = merge({}, baseContent, {
   pil: {
@@ -39,6 +40,7 @@ module.exports = merge({}, baseContent, {
   fields: {
     ...procedures.fields,
     ...species.fields,
+    ...trainingFields,
     modules: {
       label: 'Modules completed'
     },


### PR DESCRIPTION
This prevents any legacy PIL-Es from throwing errors when amended. Noting that they can only be amended to a state without a PIL-E as a normal procedure.