### PR TITLE
Don't show related tasks to users without permissions

### DIFF
--- a/pages/project/read/views/components/current-activity.jsx
+++ b/pages/project/read/views/components/current-activity.jsx
@@ -9,9 +9,9 @@ const format = (type, value, task) => {
 
 export default function CurrentActivity() {
   const project = useSelector(state => state.model);
-  const { additionalAvailability, workflowConnectionError } = useSelector(state => state.static);
+  const { additionalAvailability, workflowConnectionError, showRelatedTasks } = useSelector(state => state.static);
 
-  if (additionalAvailability) {
+  if (additionalAvailability || !showRelatedTasks) {
     return null;
   }
 


### PR DESCRIPTION
When viewing a project with open tasks as a read-only user, do not render the open tasks table if the flag to show related tasks is not set (a.k.a. the user does not have appropriate permissions).