### PR TITLE
Return changes from the first submission in PPL applications

### DIFF
--- a/pages/project-version/read/js/index.js
+++ b/pages/project-version/read/js/index.js
@@ -16,6 +16,7 @@ start({
   changes: state.static.isGranted
     ? {}
     : {
+      first: (state.static.changes && state.static.changes.first) || [],
       latest: (state.static.changes && state.static.changes.latest) || [],
       granted: (state.static.changes && state.static.changes.granted) || []
     },

--- a/pages/project-version/update/js/index.js
+++ b/pages/project-version/update/js/index.js
@@ -14,6 +14,7 @@ start({
   }),
   comments: state.static.comments,
   changes: {
+    first: (state.static.changes && state.static.changes.first) || [],
     latest: (state.static.changes && state.static.changes.latest) || [],
     granted: (state.static.changes && state.static.changes.granted) || []
   },


### PR DESCRIPTION
If looking at a draft PPL with more than 2 iterations then also return a comparison between the current version and the first submission.