### PR TITLE
Remove unwanted CSS selector

### DIFF
--- a/pages/common/assets/sass/pdf/index.scss
+++ b/pages/common/assets/sass/pdf/index.scss
@@ -154,12 +154,6 @@ dl dd {
   page-break-inside: avoid !important;
 }
 
-.granted-page.action-plan {
-  > h3:first-of-type {
-    display: none;
-  }
-}
-
 .objective-review {
   h2 {
     @extend h3;


### PR DESCRIPTION
I can't work out what this is intended to achieve, but it results in unexpected behaviour when rendering PDF documents, that is hard to decipher when working with the JSX.

Remove it, and if it has any ill effects then resolve those in the JSX directly.