### PR TITLE
Fix broken error message

### DIFF
--- a/pages/establishment/update/content/index.js
+++ b/pages/establishment/update/content/index.js
@@ -15,7 +15,7 @@ module.exports = {
     licences: {
       definedValues: 'Invalid option, select from the list of available options.'
     },
-    comments: {
+    comment: {
       required: 'Please provide a reason for making this change.'
     }
   },


### PR DESCRIPTION
The field was renamed to `comment` but this message wasn't changed