### PR TITLE
Use automatic schema config for forms

### DIFF
--- a/pages/task/read/routers/deadline-passed.js
+++ b/pages/task/read/routers/deadline-passed.js
@@ -10,13 +10,7 @@ module.exports = () => {
     next();
   });
 
-  app.use(form({
-    configure: (req, res, next) => {
-      req.schema = schema;
-      req.form.schema = req.schema;
-      next();
-    }
-  }));
+  app.use(form({ schema }));
 
   app.post('/', (req, res, next) => {
     return res.redirect(req.buildRoute('task.read', { suffix: 'confirm' }));

--- a/pages/task/read/routers/extend.js
+++ b/pages/task/read/routers/extend.js
@@ -12,11 +12,7 @@ module.exports = () => {
   });
 
   app.use(form({
-    configure: (req, res, next) => {
-      req.schema = schema;
-      req.form.schema = req.schema;
-      next();
-    },
+    schema,
     locals: (req, res, next) => {
       set(res, 'locals.static', {
         ...res.locals.static,


### PR DESCRIPTION
The built-in method for setting form schemas does a `cloneDeep` so removes any possibility of accidental schema mutation across requests. There is no need to repeat the process.

Note: this is in response to some odd integration tests failures, which are sporadic but look a lot like the result of schema mutation in task processing.