### PR TITLE
Use correct fields for experience when changing PPL holder

### DIFF
--- a/pages/project/update-licence-holder/routers/confirm.js
+++ b/pages/project/update-licence-holder/routers/confirm.js
@@ -31,7 +31,7 @@ module.exports = () => {
       return req.api(`/establishment/${req.establishmentId}/projects/${req.project.id}/project-versions/${versionId}`)
         .then(({ json: { data } }) => data)
         .then(version => {
-          req.form.experienceFields = experienceFields(version);
+          req.form.experienceFields = experienceFields(version, req.project.schemaVersion);
         })
         .then(() => next())
         .catch(next);

--- a/pages/project/update-licence-holder/routers/update.js
+++ b/pages/project/update-licence-holder/routers/update.js
@@ -25,7 +25,7 @@ module.exports = () => {
       Promise.all([getProfiles(), getProjectVersion()])
         .then(([profiles, version]) => {
           req.form.schema = getSchema(profiles);
-          req.form.experienceFields = experienceFields(version);
+          req.form.experienceFields = experienceFields(version, req.project.schemaVersion);
           if (!req.project.isLegacyStub) {
             req.form.schema = {
               ...req.form.schema,

--- a/pages/project/update-licence-holder/schema/experience-fields.js
+++ b/pages/project/update-licence-holder/schema/experience-fields.js
@@ -1,7 +1,23 @@
 const { flattenDeep, castArray } = require('lodash');
 const schema = require('@asl/projects/client/schema/v1/experience').default;
 
-module.exports = version => {
+module.exports = (version, schemaVersion) => {
+  if (schemaVersion === 0) {
+    return {
+      fields: [
+        {
+          name: 'experience-knowledge',
+          label: 'What relevant scientific knowledge or education do you have?',
+          alt: {
+            label: 'What relevant scientific knowledge or education does this person have?'
+          },
+          type: 'texteditor'
+        }
+      ],
+      fieldNames: ['experience-knowledge']
+    };
+  }
+
   const fields = schema.fields.filter(f => !f.show || f.show(version.data));
   const fieldNames = flattenDeep(fields.map(field => {
     return [

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -255,7 +255,7 @@ export default function Project({ task }) {
           <h2><Snippet>sticky-nav.experience</Snippet></h2>
           <StaticRouter>
             <ReviewFields
-              fields={experience(version).fields}
+              fields={experience(version, project.schemaVersion).fields}
               values={task.data.meta}
               project={version.data}
               readonly={true}


### PR DESCRIPTION
Legacy PPLs use a different question for PPL holder experience, so the existing set of questions from new-style PPLs does not correctly update the PPL data.

Pass the PPL schema version to the schema generator function so it can return the correct set of experience questions depending on whether the PPL is legacy or new style.