### PR TITLE
Hide the unsubmitted amendment warnings when there is an open task

### DIFF
--- a/pages/project/read/views/components/user-cannot-edit.jsx
+++ b/pages/project/read/views/components/user-cannot-edit.jsx
@@ -5,9 +5,9 @@ import Subsection from './subsection';
 
 export default function UserCannotEdit() {
   const project = useSelector(state => state.model);
-  const { asruUser, canUpdate, additionalAvailability } = useSelector(state => state.static);
+  const { asruUser, canUpdate, openTask, additionalAvailability } = useSelector(state => state.static);
 
-  if (project.status === 'inactive' || !canUpdate || additionalAvailability) {
+  if (project.status === 'inactive' || !canUpdate || openTask || additionalAvailability) {
     return null;
   }
 


### PR DESCRIPTION
We were displaying both the "Open Task" panel and the "cannot edit" panel once the amendment was submitted - we only want to display the former in that case, and vice versa.