### PR TITLE
Allow all role selectors to be removed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "8.10.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.10.1.tgz",
-      "integrity": "sha1-mT25ioU0Z+BehWOcqyS0k4gu/SA=",
+      "version": "8.10.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.10.3.tgz",
+      "integrity": "sha1-HEewXqIzmLH/Iki1TTbcrg9v13Y=",
       "requires": {
         "@asl/dictionary": "^1.1.5",
         "@ukhomeoffice/react-components": "^0.8.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^8.10.1",
+    "@asl/components": "^8.10.3",
     "@asl/constants": "^0.8.3",
     "@asl/dictionary": "^1.1.5",
     "@asl/projects": "^8.3.10",

--- a/pages/place/schema/index.js
+++ b/pages/place/schema/index.js
@@ -53,14 +53,16 @@ const baseSchema = {
   },
   nacwos: {
     inputType: 'selectMany',
-    addAnotherLabel: 'Add another NACWO',
+    addAnotherLabel: 'Add NACWO',
     removeLabel: 'Remove NACWO',
+    minRequiredFields: 0,
     nullValue: []
   },
   nvssqps: {
     inputType: 'selectMany',
-    addAnotherLabel: 'Add another NVS / SQP',
+    addAnotherLabel: 'Add NVS / SQP',
     removeLabel: 'Remove NVS / SQP',
+    minRequiredFields: 0,
     nullValue: []
   },
   restrictions: {


### PR DESCRIPTION
You could already remove an assigned NACWO / NVS by choosing the empty select option, but it wasn't obvious. Allow the user to remove the entire select box even if it's the only one.

~waiting on https://github.com/UKHomeOffice/asl-components/pull/185~