### PR TITLE
Handle null protocols when normalising protocol conditions

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -187,7 +187,7 @@ const getCacheableVersion = (req, url) => {
 const normaliseConditions = (versionData, { isSubmitted }) => {
   return mapValues(versionData, (val, key) => {
     if (key === 'protocols') {
-      return val.map(protocol => {
+      return val.filter(Boolean).map(protocol => {
         return {
           ...protocol,
           conditions: isSubmitted && sortBy(protocol.conditions, 'key')


### PR DESCRIPTION
Some protocols are null sometimes because reasons. Try not to blow up in those circumstances.