### PR TITLE
Move sorting logic on task list to pages router

### DIFF
--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -17,10 +17,6 @@ module.exports = ({
   schema = defaultSchema
 } = {}) => datatable({
   configure: (req, res, next) => {
-    req.query.rows = req.query.rows || (req.user.profile.asruUser ? 20 : 10);
-    next();
-  },
-  getApiPath: (req, res, next) => {
     const tabs = getTabs(req.user.profile);
     const progress = req.query.progress || tabs[0];
     if (!tabs.includes(progress)) {
@@ -28,6 +24,15 @@ module.exports = ({
     }
     res.locals.static.tabs = tabs;
     req.datatable.progress = progress;
+    req.datatable.sort = { column: 'updatedAt', ascending: false };
+    if (req.user.profile.asruUser && ['myTasks', 'outstanding'].includes(progress)) {
+      req.datatable.sort.ascending = true;
+    }
+    req.query.rows = req.query.rows || (req.user.profile.asruUser ? 20 : 10);
+    next();
+  },
+  getApiPath: (req, res, next) => {
+    const progress = req.datatable.progress;
     req.datatable.apiPath = [req.datatable.apiPath, { query: { ...req.query, progress } }];
     next();
   },


### PR DESCRIPTION
This means that the default sorting parameters that are applied dynamically are exposed to the client, and so can be reflected in the UI.

This in turn means that clicking the sorting header on the `updatedAt` column will _always_ reverse the sort, and you won't need to click it twice to get the latest tasks.