### PR TITLE
Fix status on revoked projects that are passed their expiry date

### DIFF
--- a/pages/project/content/index.js
+++ b/pages/project/content/index.js
@@ -42,6 +42,7 @@ module.exports = {
     granted: {
       label: 'Licence details',
       expired: 'View expired licence',
+      revoked: 'View revoked licence',
       view: 'View granted licence'
     },
     draft: {

--- a/pages/project/formatters/index.jsx
+++ b/pages/project/formatters/index.jsx
@@ -10,8 +10,6 @@ import EstablishmentLinks from '../../task/read/views/components/establishment-l
 const bad = ['expired', 'transferred', 'revoked', 'additional-availability-ended'];
 const good = ['active'];
 
-const hasExpired = (model = {}) => model.expiryDate && model.expiryDate < new Date().toISOString();
-
 const formatters = establishmentId => ({
   title: {
     format: (title, model) => {
@@ -51,10 +49,6 @@ const formatters = establishmentId => ({
       const isAdditionalAvailability = model.establishmentId !== establishmentId;
       const additionalAvailabilityEnded = isAdditionalAvailability && model.additionalEstablishments.find(e => e.id === establishmentId).status === 'removed';
 
-      if (hasExpired(model)) {
-        status = 'expired';
-      }
-
       if (additionalAvailabilityEnded) {
         status = 'additional-availability-ended';
       }
@@ -92,7 +86,7 @@ const formatters = establishmentId => ({
   },
   granted: {
     format: (granted, model) => {
-      const key = hasExpired(model) ? 'expired' : 'view';
+      const key = model.status !== 'active' ? model.status : 'view';
       return <Link page="projectVersion" versionId={granted.id} label={<Snippet>{`fields.granted.${key}`}</Snippet>} />;
     }
   },


### PR DESCRIPTION
Currently projects which are revoked but also have passed their expiry date are showing as expired rather than revoked when listed in tables.

Since all active projects have their status set to `expired` on expiry there is no reason not to trust the project status and use it directly.