### PR TITLE
Force CSRF tokens to be saved to session store

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -15,7 +15,8 @@ const generateSecret = (req, res, next) => {
     }
     req.csrfToken = tokens.create(secret);
     req.session.form[req.model.id].csrfToken = req.csrfToken;
-    return next();
+    // force the token to be persisted to the session before continuing
+    req.session.save(next);
   });
 };
 


### PR DESCRIPTION
There appears to be a race condition where the POST to a form sometimes is received before the previous token has saved, so checks the csrf token against a stale session value.

Force the token to be saved to the session store on a form GET before sending the response to ensure that the subsequent POST will always have the fresh value.