### PR TITLE
Ungranted pdfs should always be the application

### DIFF
--- a/pages/project/read/views/components/current-version.jsx
+++ b/pages/project/read/views/components/current-version.jsx
@@ -49,6 +49,7 @@ export default function CurrentVersion() {
       <p>
         <Link
           page="projectVersion.pdf"
+          query={project.granted ? null : { application: true }}
           versionId={versionId}
           label={<Snippet>{`actions.view.${labelKeyPdf}`}</Snippet>}
         />


### PR DESCRIPTION
The pdf link on the overview page was linking to the "licence" view pdf rather than the application view.