### PR TITLE
Show notes on old cat F pils which are converted to cat E

### DIFF
--- a/pages/pil/procedures/views/diff.jsx
+++ b/pages/pil/procedures/views/diff.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import isEqual from 'lodash/isEqual';
-import { Snippet, Inset } from '@asl/components';
+import { Snippet, Inset, Markdown } from '@asl/components';
 import TrainingPil from '../../unscoped/courses/participants/read/views/training-pil';
 
 const Item = ({
@@ -70,9 +70,15 @@ export default function ProceduresDiff({
                     </Inset>
                 }
                 {
-                  procedure.key === 'E' && (
-                    <TrainingPil trainingPil={procedure} />
-                  )
+                  procedure.key === 'E' && <Fragment>
+                    {
+                      // some cat E pils are converted cat F
+                      // these don't have any training course data but will have a note
+                      procedure.trainingCourse
+                        ? <TrainingPil trainingPil={procedure} />
+                        : <Inset><Markdown>{ afterPil.notesCatF }</Markdown></Inset>
+                    }
+                  </Fragment>
                 }
               </li>
             )


### PR DESCRIPTION
160 PILs in production have been updated from categroy F to category E. These don't have any training course metadata attched to them, but do have a note.

For those cases when rendering the PIL on the PIL page we want to show the notes instead of blank training course data.