### PR TITLE
Don't try to load comment on AA project applications

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -22,6 +22,10 @@ const getComments = (action = 'grant') => (req, res, next) => {
   if (!req.project || !req.project.openTasks || !req.project.openTasks.length) {
     return next();
   }
+  if (req.project.establishmentId !== req.establishmentId) {
+    // the application task for AA projects won't be visible so don't try to load it
+    return next();
+  }
   const task = get(req.project, 'openTasks', []).find(task => task.data.action === action);
   if (!task) {
     return next();


### PR DESCRIPTION
If there is an open task in progress on an AA project don't try to load the comments if viewing from an additional establishment. The request to the task will fail causing an error because it is a task from another establishment.