### PR TITLE
Filter available versions for comparison based on user type

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -138,23 +138,16 @@ const getFirstVersion = (req, type = 'project-versions') => {
   if (!req.project) {
     return Promise.resolve();
   }
-  if (type === 'project-versions') {
-    // first version is only used during application process
-    if (req.project && req.project.granted) {
-      return Promise.resolve();
-    }
-    // if there are only one or two versions then the first version will be the same as current or previous
-    if (req.project.versions.length < 3) {
-      return Promise.resolve();
-    }
-  } else {
-    // if there are only one or two ra versions then the first version will be the same as current or previous
-    if (req.project.retrospectiveAssessments.length < 3) {
-      return Promise.resolve();
-    }
+  // no first submission for granted projects
+  if (type === 'project-versions' && req.project.granted) {
+    return Promise.resolve();
   }
   const key = type === 'project-versions' ? 'versions' : 'retrospectiveAssessments';
   const versions = req.project[key].filter(canViewVersion(req.user));
+  // if there are only one or two versions then the first version will be the same as current or previous
+  if (versions.length < 3) {
+    return Promise.resolve();
+  }
   const first = sortBy(versions, 'createdAt')[0];
   return getCacheableVersion(req, `/establishments/${req.establishmentId}/projects/${req.projectId}/${type}/${first.id}`)
     // swallow error as this will return 403 for receiving establishment viewing a project transfer version

--- a/pages/project-version/read/index.js
+++ b/pages/project-version/read/index.js
@@ -28,7 +28,7 @@ module.exports = settings => {
     res.locals.static.basename = req.fullApplication ? req.buildRoute('projectVersion.fullApplication') : req.buildRoute('projectVersion');
     res.locals.static.projectUrl = req.buildRoute('project.read');
     res.locals.static.establishment = req.project.establishment;
-    res.locals.static.isActionable = req.user.profile.asruUser && get(task, 'data.data.version') === req.versionId;
+    res.locals.static.isActionable = get(task, 'data.data.version') === req.versionId;
     res.locals.static.user = req.user.profile;
     res.locals.static.showComments = showComments;
     res.locals.static.commentable = showComments && req.user.profile.asruUser && res.locals.static.isCommentable;

--- a/pages/task/schema/confirm.js
+++ b/pages/task/schema/confirm.js
@@ -19,6 +19,9 @@ module.exports = (task, chosenStatus) => {
     if (action === 'grant-ra') {
       return false;
     }
+    if (chosenStatus === 'returned-to-applicant') {
+      return false;
+    }
     return model === 'project' && status === 'awaiting-endorsement' && !wasAwerbed;
   };
 


### PR DESCRIPTION
ASRU users should not see comparison of draft PPL/RA versions which have not been endorsed for submission to ASRU.

When finding the available versions for comparison then use a filtered list when request is being made as an ASRU user. Establishment users will see all available versions.