### PR TITLE
Remove invisible unicode from editor values in comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/projects": {
-      "version": "9.3.6",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-9.3.6.tgz",
-      "integrity": "sha1-Chgem29Z3mZJYuV9srogPVnun3g=",
+      "version": "9.3.8",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-9.3.8.tgz",
+      "integrity": "sha1-0VFzDPmVsry9j+iwhdmw9ymoHDs=",
       "requires": {
         "@asl/components": "^9.0.1",
         "@asl/constants": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@asl/components": "^9.0.1",
     "@asl/constants": "^0.8.3",
     "@asl/dictionary": "^1.1.5",
-    "@asl/projects": "^9.3.6",
+    "@asl/projects": "^9.3.8",
     "@asl/service": "^8.6.2",
     "@joefitter/docx": "^4.7.0",
     "@ukhomeoffice/frontend-toolkit": "^2.13.0",

--- a/pages/project-version/middleware/diff/compare.js
+++ b/pages/project-version/middleware/diff/compare.js
@@ -1,0 +1,80 @@
+const { Value } = require('slate');
+const { diffWords, diffSentences, diffArrays } = require('diff');
+const last = require('lodash/last');
+
+const parseValue = (val) => {
+  if (typeof val === 'string') {
+    val = JSON.parse(val || '{}');
+  }
+  return Value.fromJSON(val || {});
+};
+
+// eslint-disable-next-line no-control-regex
+const normaliseWhitespace = str => str.replace(/[\u0000-\u0008\u000B-\u0019\u001b\u009b\u00ad\u200b\u2028\u2029\ufeff\ufe00-\ufe0f]/g, '');
+
+const diff = (a, b, { type, granularity = 'word' }) => {
+
+  let diff = [];
+  let added = [];
+  let removed = [];
+  let before;
+  let after;
+  let diffs;
+
+  switch (type) {
+    case 'text':
+      diff = diffWords(a || '', b || '');
+      break;
+    case 'checkbox':
+    case 'location-selector':
+    case 'objective-selector':
+    case 'permissible-purpose':
+    case 'species-selector':
+      diff = diffArrays((a || []).sort(), (b || []).sort());
+      break;
+    case 'texteditor':
+
+      try {
+        before = parseValue(a);
+        after = parseValue(b);
+      } catch (e) {
+        return { error: e, added: [], removed: [] };
+      }
+
+      if (granularity === 'word') {
+        diffs = diffWords(normaliseWhitespace(before.document.text), normaliseWhitespace(after.document.text));
+      } else {
+        diffs = diffSentences(normaliseWhitespace(before.document.text), normaliseWhitespace(after.document.text));
+      }
+
+      removed = diffs.reduce((arr, d) => {
+        // ignore additions
+        if (!d.added) {
+          const prev = last(arr);
+          const start = prev ? prev.start + prev.count : 0;
+          return [...arr, { ...d, start, count: d.value.length }];
+        }
+        return arr;
+      }, []).filter(d => d.removed);
+
+      added = diffs.reduce((arr, d) => {
+        // ignore removals
+        if (!d.removed) {
+          const prev = last(arr);
+          const start = prev ? prev.start + prev.count : 0;
+          return [...arr, { ...d, start, count: d.value.length }];
+        }
+        return arr;
+      }, []).filter(d => d.added);
+
+      return { added, removed, granularity };
+  }
+
+  return {
+    added: diff.filter(item => !item.removed),
+    removed: diff.filter(item => !item.added),
+    granularity
+  };
+};
+
+module.exports = diff;

--- a/pages/project-version/middleware/diff/worker.js
+++ b/pages/project-version/middleware/diff/worker.js
@@ -1,88 +1,13 @@
+const compare = require('./compare');
 const { parentPort, workerData } = require('worker_threads');
-
-const { Value } = require('slate');
-const { diffWords, diffSentences, diffArrays } = require('diff');
-const last = require('lodash/last');
-
-const parseValue = (val) => {
-  if (typeof val === 'string') {
-    val = JSON.parse(val || '{}');
-  }
-  return Value.fromJSON(val || {});
-};
-
-const diff = (a, b, { type, granularity }) => {
-
-  let diff = [];
-  let added = [];
-  let removed = [];
-  let before;
-  let after;
-  let diffs;
-
-  switch (type) {
-    case 'text':
-      diff = diffWords(a || '', b || '');
-      break;
-    case 'checkbox':
-    case 'location-selector':
-    case 'objective-selector':
-    case 'permissible-purpose':
-    case 'species-selector':
-      diff = diffArrays((a || []).sort(), (b || []).sort());
-      break;
-    case 'texteditor':
-
-      try {
-        before = parseValue(a);
-        after = parseValue(b);
-      } catch (e) {
-        return { error: e, added: [], removed: [] };
-      }
-
-      if (granularity === 'word') {
-        diffs = diffWords(before.document.text, after.document.text);
-      } else {
-        diffs = diffSentences(before.document.text, after.document.text);
-      }
-
-      removed = diffs.reduce((arr, d) => {
-        // ignore additions
-        if (!d.added) {
-          const prev = last(arr);
-          const start = prev ? prev.start + prev.count : 0;
-          return [...arr, { ...d, start, count: d.value.length }];
-        }
-        return arr;
-      }, []).filter(d => d.removed);
-
-      added = diffs.reduce((arr, d) => {
-        // ignore removals
-        if (!d.removed) {
-          const prev = last(arr);
-          const start = prev ? prev.start + prev.count : 0;
-          return [...arr, { ...d, start, count: d.value.length }];
-        }
-        return arr;
-      }, []).filter(d => d.added);
-
-      return { added, removed, granularity };
-  }
-
-  return {
-    added: diff.filter(item => !item.removed),
-    removed: diff.filter(item => !item.added),
-    granularity
-  };
-};
 
 const { before, after, type } = workerData;
 
 if (type === 'texteditor') {
-  const sentences = diff(before, after, { type, granularity: 'sentence' });
+  const sentences = compare(before, after, { type, granularity: 'sentence' });
   parentPort.postMessage({ ...sentences });
-  const words = diff(before, after, { type, granularity: 'word' });
+  const words = compare(before, after, { type, granularity: 'word' });
   parentPort.postMessage({ ...words });
 } else {
-  parentPort.postMessage(diff(before, after, { type }));
+  parentPort.postMessage(compare(before, after, { type }));
 }


### PR DESCRIPTION
Invisible unicode characters like `\uFEFF` cause word boundaries to be added where none actually exist, and string lengths to be miscalculated.

Remove any invisible unicode control characters from text before performing comparison to ensure that the changes render correctly.

~WIP pending projects bump~