### PR TITLE
Use `lodash.get` to read action property

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -28,7 +28,7 @@ const getComments = (action = 'grant') => (req, res, next) => {
     // the application task for AA projects won't be visible so don't try to load it
     return next();
   }
-  const task = get(req.project, 'openTasks', []).find(task => task.data.action === action);
+  const task = get(req.project, 'openTasks', []).find(task => get(task, 'data.action') === action);
   if (!task) {
     return next();
   }


### PR DESCRIPTION
Workflow can sometimes respond with an error object and not a task, which means `task.data.action` throws an error because there is no data property.

Use `get` to access the action to avoid an unnecessary error when that happens.