### PR TITLE
Prevent changing licence holder when there is an amendment

### DIFF
--- a/pages/project/read/views/components/start-amendment.jsx
+++ b/pages/project/read/views/components/start-amendment.jsx
@@ -52,7 +52,7 @@ export default function StartAmendment() {
     startAmendmentDescriptionKey = 'transfer';
   }
 
-  const canChangeLicenceHolder = !openTask && canUpdate && project.status === 'active' && (!project.isLegacyStub || (project.isLegacyStub && asruLicensing));
+  const canChangeLicenceHolder = !project.draft && !openTask && canUpdate && project.status === 'active' && (!project.isLegacyStub || (project.isLegacyStub && asruLicensing));
 
   return (
     <Subsection

--- a/pages/project/update-licence-holder/routers/confirm.js
+++ b/pages/project/update-licence-holder/routers/confirm.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const { get, omit, merge } = require('lodash');
+const { BadRequestError } = require('@asl/service/errors');
 const form = require('../../../common/routers/form');
 const experienceFields = require('../schema/experience-fields');
 const { updateDataFromTask, redirectToTaskIfOpen } = require('../../../common/middleware');
@@ -52,6 +53,9 @@ module.exports = () => {
   app.post('/', redirectToTaskIfOpen());
 
   app.post('/', (req, res, next) => {
+    if (req.project.draft && req.project.status === 'active') {
+      return next(new BadRequestError('Cannot change licence holder while an amendment is in progress'));
+    }
     sendData(req)
       .then(response => {
         req.session.success = { taskId: get(response, 'json.data.id') };

--- a/pages/project/update-licence-holder/views/index.jsx
+++ b/pages/project/update-licence-holder/views/index.jsx
@@ -6,7 +6,8 @@ import {
   Header,
   Snippet,
   WidthContainer,
-  Fieldset
+  Fieldset,
+  Link
 } from '@asl/components';
 import { Button } from '@ukhomeoffice/react-components';
 import RTEFieldset from '@asl/projects/client/components/fieldset';
@@ -51,6 +52,15 @@ const FormBody = ({ fields, model, formFields, submit, project }) => {
 const UpdateLicenceHolder = () => {
   const model = useSelector(state => state.model);
   const { fields, project } = useSelector(state => state.static);
+
+  if (project.draft && project.status === 'active') {
+    return <Fragment>
+      <h1>You cannot change the licence holder while an amendment is in progress.</h1>
+      <p>Discard or complete the amendment to continue.</p>
+      <p><Link page="project.read" label="Back to project" /></p>
+    </Fragment>;
+  }
+
   return <Fragment>
     <ErrorSummary />
     <Header


### PR DESCRIPTION
Don't allow PPL holder changes to be made if there is an open, but unsubmitted PPL amendment in progress.