### PR TITLE
Add default values for ROP species

### DIFF
--- a/pages/rops/update/config.js
+++ b/pages/rops/update/config.js
@@ -27,8 +27,8 @@ function schedule2Applicable(req, placesOfBirth = []) {
     'europe',
     'rest-of-world'
   ];
-  const projectSpecies = get(req, 'rop.project.granted.data.species', []);
-  const ropSpecies = get(req, 'rop.species', {});
+  const projectSpecies = get(req, 'rop.project.granted.data.species', []) || [];
+  const ropSpecies = get(req, 'rop.species', {}) || {};
   const ropPrecoded = ropSpecies.precoded || [];
   const ropOthers = flatten(Object.keys(ropSpecies).filter(k => k !== 'precoded').map(k => ropSpecies[k]));
 


### PR DESCRIPTION
If a value is `null` then `lodash.get` retains the null rather than applying the fallback, so this needs a separate default value to avoid `ropSpecies.precoded` throwing an error when `ropSpecies` is null (which it seems to be if you answer "No" to the "any more species" question).