### PR TITLE
Add BOM to CSV downloads

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -144,6 +144,7 @@ module.exports = ({
     res.attachment('data.csv');
     const schema = res.locals.datatable.schema;
     const stringifier = csv({
+      bom: true,
       header: true,
       columns: Object.keys(schema)
         .filter(key => !schema[key].omitFromCSV)


### PR DESCRIPTION
This allows UTF8 characters to render correctly in Excel.