### PR TITLE
Default to `{}` if species is null

### DIFF
--- a/pages/rops/procedures/schema/index.js
+++ b/pages/rops/procedures/schema/index.js
@@ -191,7 +191,7 @@ module.exports = (req, addMultiple) => {
   const hasGa = get(req, 'rop.ga', false);
   const species = [
     ...projectSpecies,
-    ...flatten(Object.values(get(req, 'rop.species', {})))
+    ...flatten(Object.values(get(req, 'rop.species') || {}))
   ];
   const newGeneticLine = req.rop.newGeneticLine;
   const newGeneticLineOptions = newGeneticLine ? [false, true] : [false];


### PR DESCRIPTION
If no extra species are added then the rop species list is `null`. Set a default value so `Object.values` doesn't throw.