### PR TITLE
Don't include revoked PIL procedures on PIL-E tasks

### DIFF
--- a/pages/task/read/views/models/training-pil.jsx
+++ b/pages/task/read/views/models/training-pil.jsx
@@ -22,7 +22,7 @@ export function PilProcedures({ task, isPil = false }) {
     return <TrainingPilView trainingPil={data} />;
   }
 
-  let before = ((pil && pil.procedures) || [])
+  let before = ((pil && pil.status === 'active' && pil.procedures) || [])
     .map(p => ({ key: p }))
     .concat(profileCatEs.map(p => ({ ...p, key: 'E' })));
 


### PR DESCRIPTION
If a user has an old revoked PIL, then these procedures are still included on the task page when applying for a PIL, which has led to some confusion with inspectors/LOs who are uncertain if this will re-activate the old procedures.