### PR TITLE
Allow visibility of PPL issue date to users who cannot change it

### DIFF
--- a/pages/project/read/views/components/details.jsx
+++ b/pages/project/read/views/components/details.jsx
@@ -58,17 +58,17 @@ export default function Details() {
                   </Fragment>
                 }
               </dd>
-              {
-                allowedActions.includes('project.updateIssueDate') &&
-                  <Fragment>
-                    <dt><Snippet>fields.issueDate.label</Snippet></dt>
-                    <dd>
-                      {formatDate(project.issueDate, dateFormat.long)}
+              <dt><Snippet>fields.issueDate.label</Snippet></dt>
+              <dd>
+                {formatDate(project.issueDate, dateFormat.long)}
+                {
+                  allowedActions.includes('project.updateIssueDate') &&
+                    <Fragment>
                       <br />
                       <Link page="projectAsruActions.updateIssueDate" label="Change" />
-                    </dd>
-                  </Fragment>
-              }
+                    </Fragment>
+                }
+              </dd>
               {
                 project.amendedDate &&
                 <Fragment>


### PR DESCRIPTION
The permissions check was too high up so was hiding the issue date of PPLs to everyone except ASRU licensing officers.