### PR TITLE
Bugfix - remove species from rop if no other species selected

### DIFF
--- a/pages/common/routers/multi-step.js
+++ b/pages/common/routers/multi-step.js
@@ -78,12 +78,20 @@ module.exports = ({ schema, config, root, postData = (req, res, next) => next() 
 
   app.use(form({
     configure(req, res, next) {
+      req.multiStep = {};
       req.form.schema = pick(schema(req), req.config.fields);
       next();
     },
     locals: (req, res, next) => {
       if (req.config.locals) {
         merge(res.locals.static, req.config.locals(req));
+      }
+      next();
+    },
+    process: (req, res, next) => {
+      req.multiStep.values = req.form.values;
+      if (req.config.process) {
+        req.config.process(req);
       }
       next();
     }

--- a/pages/rops/update/config.js
+++ b/pages/rops/update/config.js
@@ -84,7 +84,12 @@ module.exports = {
   },
   species: {
     fields: ['otherSpecies', 'species'],
-    section: 'animals'
+    section: 'animals',
+    process: req => {
+      if (req.multiStep.values.otherSpecies === false) {
+        req.multiStep.values.species = null;
+      }
+    }
   },
   reuse: {
     fields: ['reuse'],

--- a/pages/rops/update/index.js
+++ b/pages/rops/update/index.js
@@ -20,7 +20,7 @@ module.exports = () => {
       const params = {
         method: 'PUT',
         json: {
-          data: req.form.values
+          data: req.multiStep.values
         }
       };
       req.api(`/establishment/${req.establishmentId}/project/${req.projectId}/rop/${req.ropId}`, params)

--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -1,4 +1,4 @@
-const { flatten, get } = require('lodash');
+const { flatten, get, intersection } = require('lodash');
 const { toBoolean, toArray } = require('../../../../lib/utils');
 
 module.exports = req => {
@@ -61,6 +61,10 @@ module.exports = req => {
       return getSpeciesField();
     }
 
+    const ropSpecies = flatten(Object.values(req.rop.species || {}));
+    // cannot select "no other species" as already added to procs
+    const disableOtherSpecies = !!intersection(ropSpecies, req.rop.procedures.map(p => p.species)).length;
+
     return {
       otherSpecies: {
         inputType: 'radioGroup',
@@ -83,8 +87,12 @@ module.exports = req => {
             }
           }
         ],
+        disabled: true,
         options: [
-          false,
+          {
+            value: false,
+            disabled: disableOtherSpecies
+          },
           {
             value: true,
             reveal: getSpeciesField()


### PR DESCRIPTION
* If no other species selected, then species are removed from rop
* This functionality is disabled if any of the rop species have had procs added