### PR TITLE
Check establishment id when removing roles

### DIFF
--- a/pages/role/remove/index.js
+++ b/pages/role/remove/index.js
@@ -7,7 +7,7 @@ const success = require('../routers/success');
 
 const sendData = (req) => {
   const { type, comment } = req.session.form[req.model.id].values;
-  const roleId = req.profile.roles.find(r => r.type === type).id;
+  const roleId = req.profile.roles.find(r => r.type === type && r.establishmentId === req.establishmentId).id;
 
   const opts = {
     method: 'DELETE',


### PR DESCRIPTION
If a user holds the same role at multiple establishments then the `find` doesn't reliably return the right one.

This results in broken tasks that can't be loaded because the establishment id and role id don't match so throw 404s.