### PR TITLE
Handle user not clicking "Done" when adding place restrictions

### DIFF
--- a/pages/place/routers/update.js
+++ b/pages/place/routers/update.js
@@ -21,6 +21,11 @@ module.exports = () => {
       let nvssqps = get(req.body, 'nvssqps');
       req.form.values.nacwos = uniq(Array.isArray(nacwos) ? nacwos : [nacwos]).filter(Boolean);
       req.form.values.nvssqps = uniq(Array.isArray(nvssqps) ? nvssqps : [nvssqps]).filter(Boolean);
+
+      // if user does not click "Done" on restrictions then the value is posted twice as an array
+      if (Array.isArray(req.body.restrictions)) {
+        req.form.values.restrictions = req.body.restrictions[0];
+      }
       next();
     },
     cancelEdit: (req, res, next) => {


### PR DESCRIPTION
If the user does not click done on restrictions when adding/editing a place then there is a hidden field and textarea with the same name/value posted, and so the value appears twice in the POST body as an array.

Normalise this back to a single field if it occurs.