### PR TITLE
Fix ROPs year in reporting tab of project overview

### DIFF
--- a/pages/project/read/views/components/rops.jsx
+++ b/pages/project/read/views/components/rops.jsx
@@ -15,7 +15,7 @@ export default function Rops() {
   return (
     <Subsection
       title={<Snippet>rops.title</Snippet>}
-      content={<Snippet year={format(project.ropsDeadline, 'YYYY')}>{ submittedRop ? 'rops.submitted' : 'rops.content' }</Snippet>}
+      content={<Snippet year="2021">{ submittedRop ? 'rops.submitted' : 'rops.content' }</Snippet>}
     >
       {
         submittedRop


### PR DESCRIPTION
If the year for the ROP is inferred from the calculated deadline then it will generally be off by one as the deadline for most 2021 ROPs is in January 2022.

Hard-code 2021 until handling multiple years becomes relevant in late 2021/early 2022 and a proper design spec is created.

<img width="500" alt="Screenshot 2021-05-04 at 16 18 54" src="https://user-images.githubusercontent.com/117398/117027306-7c292100-acf4-11eb-9b32-8063088f5acf.png">
