### PR TITLE
Remove "Other" species added in ROP setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,15 +27,6 @@
         "url": "^0.11.0"
       },
       "dependencies": {
-        "@ukhomeoffice/react-components": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.9.2.tgz",
-          "integrity": "sha512-pKE+3993gqDibExgylJ8RaQm26ISBQXpdfbd+4TOK+ND+laZE2Bg+ig+0/TdQTT7xSAi7a5WI+quA2iNTt2xug==",
-          "requires": {
-            "classnames": "^2.2.6",
-            "react-markdown": "^4.0.8"
-          }
-        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2153,6 +2144,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -2193,6 +2193,37 @@
       "requires": {
         "jszip": "*"
       }
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/react": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
+      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.16.tgz",
+      "integrity": "sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -4442,6 +4473,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "csv-stringify": {
       "version": "5.6.1",
@@ -10190,11 +10226,12 @@
       }
     },
     "react-redux": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
-      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
+      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
       "requires": {
         "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
         "hoist-non-react-statics": "^3.3.2",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",

--- a/pages/rops/procedures/schema/index.js
+++ b/pages/rops/procedures/schema/index.js
@@ -210,10 +210,12 @@ function getPurposes(req) {
 
 module.exports = (req, addMultiple) => {
   const projectSpecies = (get(req, 'rop.project.granted.data.species') || []).filter(s => !s.includes('other'));
+  const ropSpecies = flatten(Object.values(get(req, 'rop.species') || {})).filter(s => !s.match(/^other-/));
+
   const hasGa = get(req, 'rop.ga', false);
   const species = [
     ...projectSpecies,
-    ...flatten(Object.values(get(req, 'rop.species') || {}))
+    ...ropSpecies
   ];
   const newGeneticLine = req.rop.newGeneticLine;
   const newGeneticLineOptions = newGeneticLine ? [false, true] : [false];


### PR DESCRIPTION
Where a user has selected an "other" species group in the setup questions and provided a text input, both the "Other" value and the text input are presented as options on the procedures input screen.

Filter the values to get rid of any `other-*` values.