### PR TITLE
Add ScrollWrapper component to show indicators on wide elements when scrollable

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -639,3 +639,34 @@ nav.bottom-nav {
 .pre-release {
   display: none !important;
 }
+
+.overflow-wrapper {
+  position: relative;
+
+  .overflow-inner {
+    overflow: auto;
+  }
+
+  &:before, &:after {
+    content: " ";
+    height: 100%;
+    position: absolute;
+    top: 0;
+    width: 10px;
+    display: none;
+  }
+  &:before {
+    background: radial-gradient(ellipse farthest-side at left 50%, rgba(0,0,0,0.3), transparent);
+    left: 0;
+  }
+  &:after {
+    background: radial-gradient(ellipse farthest-side at right 50%, rgba(0,0,0,0.3), transparent);
+    right: 0;
+  }
+  &.overflow-left:before {
+    display: block;
+  }
+  &.overflow-right:after {
+    display: block;
+  }
+}

--- a/pages/common/components/overflow-wrapper.jsx
+++ b/pages/common/components/overflow-wrapper.jsx
@@ -1,0 +1,27 @@
+import React, { useState, useRef, useEffect } from 'react';
+import classnames from 'classnames';
+
+const OverflowWrapper = ({ children }) => {
+
+  const ref = useRef(null);
+  const [overflow, setOverflow] = useState({ left: false, right: false });
+
+  const scroll = () => {
+    // show left shadow if user has scrolled at all
+    const left = ref.current.scrollLeft > 0;
+    // show right shadow if scroll distance is less than the full width
+    const right = ref.current.scrollLeft + ref.current.offsetWidth < ref.current.scrollWidth;
+    setOverflow({ left, right });
+  };
+
+  // update once on initialisation
+  useEffect(scroll, []);
+
+  return <div className={classnames('overflow-wrapper', { 'overflow-left': overflow.left, 'overflow-right': overflow.right })}>
+    <div className="overflow-inner" onScroll={scroll} ref={ref}>
+      { children }
+    </div>
+  </div>;
+};
+
+export default OverflowWrapper;

--- a/pages/rops/procedures/list/views/index.jsx
+++ b/pages/rops/procedures/list/views/index.jsx
@@ -12,6 +12,7 @@ import { getUrl } from '@asl/components/src/link';
 import { Button } from '@ukhomeoffice/react-components';
 import flatten from 'lodash/flatten';
 import Confirm from '../../../update/views/components/confirm';
+import OverflowWrapper from '../../../../common/components/overflow-wrapper';
 import { projectSpecies } from '@asl/constants';
 
 const allSpecies = flatten(Object.values(projectSpecies));
@@ -172,9 +173,9 @@ export default function Procedures() {
       {
         hasProcedures
           ? (
-            <div style={{ overflowX: 'scroll', maxWidth: '2000px' }}>
+            <OverflowWrapper>
               <Datatable formatters={formatters} Actions={editable && Actions} />
-            </div>
+            </OverflowWrapper>
           )
           : <p><em>No procedures added</em></p>
       }


### PR DESCRIPTION
This adds a gradient on each side of the container when it is hidden by horizontal scrolling.

## Example:
<img width="1257" alt="Screenshot 2021-05-06 at 15 15 24" src="https://user-images.githubusercontent.com/117398/117313682-051f9400-ae7e-11eb-9d8a-63b4b7e95836.png">
<img width="1256" alt="Screenshot 2021-05-06 at 15 15 38" src="https://user-images.githubusercontent.com/117398/117313688-081a8480-ae7e-11eb-9e3d-ce4b8af8e253.png">
<img width="1254" alt="Screenshot 2021-05-06 at 15 15 48" src="https://user-images.githubusercontent.com/117398/117313696-08b31b00-ae7e-11eb-9953-97f9e83aab5a.png">
