### PR TITLE
Show "My Tasks" for all LOs and inspectors

### DIFF
--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -4,7 +4,7 @@ const defaultSchema = require('./schema');
 const datatable = require('../../common/routers/datatable');
 
 const hasMyTasks = profile => {
-  return profile.asruUser && profile.asru && profile.asru.length > 0;
+  return profile.asruUser && (profile.asruLicensing || profile.asruInspector);
 };
 
 const getTabs = profile => {


### PR DESCRIPTION
A user can have assigned tasks in this list even if they don't have any establishment affiliations, so need to show it for any ASRU user who might have assigned and processable tasks (a.k.a. LOs and inspectors).