### PR TITLE
Split name into two columns in establishment PIL lists

### DIFF
--- a/pages/establishment/licence-fees/personal/schema/index.js
+++ b/pages/establishment/licence-fees/personal/schema/index.js
@@ -3,7 +3,15 @@ module.exports = req => {
     licenceHolder: {
       show: true,
       sort: 'lastName',
-      toCSVString: (_, row) => `${row.profile.firstName} ${row.profile.lastName}`
+      omitFromCSV: true
+    },
+    firstName: {
+      show: false,
+      toCSVString: (_, row) => row.profile.firstName
+    },
+    lastName: {
+      show: false,
+      toCSVString: (_, row) => row.profile.lastName
     },
     licenceNumber: {
       show: true,

--- a/pages/pil/unscoped/list/schema/index.js
+++ b/pages/pil/unscoped/list/schema/index.js
@@ -17,7 +17,17 @@ module.exports = {
     show: true,
     title: 'Licence holder',
     sort: 'profile.lastName',
-    toCSVString: licenceHolder => `${licenceHolder.firstName} ${licenceHolder.lastName}`
+    omitFromCSV: true
+  },
+  firstName: {
+    title: 'First name',
+    show: false,
+    toCSVString: (_, row) => row.profile.firstName
+  },
+  lastName: {
+    title: 'Last name',
+    show: false,
+    toCSVString: (_, row) => row.profile.lastName
   },
   licenceNumber: {
     show: true,


### PR DESCRIPTION
Establishments requested that the two name fields be separate to make them easier to work with.