### PR TITLE
Don't show null changes in diffs

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -29,8 +29,8 @@ const getValue = ({ row, schema, key }) => {
 const hasChanged = (newValue, oldValue, { accessor } = {}) => {
   oldValue = get(oldValue, accessor, oldValue);
   newValue = get(newValue, accessor, newValue);
-  if (oldValue === undefined || oldValue === null) {
-    return !!newValue;
+  if (!oldValue && !newValue) {
+    return false;
   }
   if (Array.isArray(newValue)) {
     newValue = [ ...newValue ].map(v => get(v, accessor, v)).sort();


### PR DESCRIPTION
If before and after values are both falsy then don't flag a change