### PR TITLE
include "other" free-text when rendering regulatory subpurposes

### DIFF
--- a/pages/rops/procedures/list/formatters/index.jsx
+++ b/pages/rops/procedures/list/formatters/index.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import flatten from 'lodash/flatten';
+import get from 'lodash/get';
 import { projectSpecies } from '@asl/constants';
 import { Snippet } from '@asl/components';
 
@@ -20,61 +21,85 @@ export function formatSpecies(s) {
   return species ? species.label : s;
 }
 
-const getRadioOption = field => v => {
+export function getOtherValue(field, rop) {
+  const otherFields = {
+    'routine-other': 'regulatorySubpurposesOther',
+    'other-efficacy': 'regulatorySubpurposesOtherEfficacy',
+    'other-toxicity': 'regulatorySubpurposesOtherToxicity',
+    'other-toxicity-ecotoxicity': 'regulatorySubpurposesOtherToxicityEcotoxicity'
+  };
+  return get(rop, otherFields[field]);
+}
+
+const getRadioOption = field => (v, rop) => {
   if (!v) {
     return '-';
   }
+
+  if (field === 'regulatorySubpurposes' && v.includes('other')) {
+    const otherValue = getOtherValue(v, rop);
+
+    if (otherValue) {
+      return <Fragment>
+        <Snippet fallback={`fields.${field}.options.${v}`}>{`fields.${field}.options.${v}.label`}</Snippet>
+        <span>: {otherValue}</span>
+      </Fragment>;
+    }
+  }
+
   return <Snippet fallback={`fields.${field}.options.${v}`}>{`fields.${field}.options.${v}.label`}</Snippet>;
 };
 
-const formatters = {
-  species: {
-    format: formatSpecies
-  },
-  reuse: {
-    format: yn
-  },
-  placesOfBirth: {
-    format: getRadioOption('placesOfBirth')
-  },
-  nhpsOrigin: {
-    format: getRadioOption('nhpsOrigin')
-  },
-  nhpsColonyStatus: {
-    format: getRadioOption('nhpsColonyStatus')
-  },
-  nhpsGeneration: {
-    format: getRadioOption('nhpsGeneration')
-  },
-  ga: {
-    format: getRadioOption('ga')
-  },
-  newGeneticLine: {
-    format: yn
-  },
-  purposes: {
-    format: getRadioOption('purposes')
-  },
-  subpurpose: {
-    format: (v, model) => {
-      switch (model.purposes) {
-        case 'basic':
-          return getRadioOption('basicSubpurposes')(model.basicSubpurposes);
-        case 'regulatory':
-          return getRadioOption('regulatorySubpurposes')(model.regulatorySubpurposes);
-        case 'translational':
-          return getRadioOption('translationalSubpurposes')(model.translationalSubpurposes);
-        default:
-          return '-';
+const formatters = rop => {
+  return {
+    species: {
+      format: formatSpecies
+    },
+    reuse: {
+      format: yn
+    },
+    placesOfBirth: {
+      format: getRadioOption('placesOfBirth')
+    },
+    nhpsOrigin: {
+      format: getRadioOption('nhpsOrigin')
+    },
+    nhpsColonyStatus: {
+      format: getRadioOption('nhpsColonyStatus')
+    },
+    nhpsGeneration: {
+      format: getRadioOption('nhpsGeneration')
+    },
+    ga: {
+      format: getRadioOption('ga')
+    },
+    newGeneticLine: {
+      format: yn
+    },
+    purposes: {
+      format: getRadioOption('purposes')
+    },
+    subpurpose: {
+      format: (v, model) => {
+        switch (model.purposes) {
+          case 'basic':
+            return getRadioOption('basicSubpurposes')(model.basicSubpurposes);
+          case 'regulatory':
+            return getRadioOption('regulatorySubpurposes')(model.regulatorySubpurposes, rop);
+          case 'translational':
+            return getRadioOption('translationalSubpurposes')(model.translationalSubpurposes);
+          default:
+            return '-';
+        }
       }
+    },
+    regulatoryLegislation: {
+      format: getRadioOption('regulatoryLegislation')
+    },
+    severity: {
+      format: getRadioOption('severity')
     }
-  },
-  regulatoryLegislation: {
-    format: getRadioOption('regulatoryLegislation')
-  },
-  severity: {
-    format: getRadioOption('severity')
-  }
+  };
 };
 
 export default formatters;

--- a/pages/rops/procedures/list/index.js
+++ b/pages/rops/procedures/list/index.js
@@ -1,7 +1,7 @@
 const { page } = require('@asl/service/ui');
 const { pickBy, some } = require('lodash');
 const { datatable } = require('../../../common/routers');
-const schema = require('./schema');
+const getSchema = require('./schema');
 
 module.exports = () => {
   const app = page({ root: __dirname });
@@ -9,19 +9,19 @@ module.exports = () => {
   app.use(datatable({
     configure: (req, res, next) => {
       req.datatable.apiPath = `/establishment/${req.establishmentId}/project/${req.projectId}/rop/${req.ropId}/procedures`;
-      // req.datatable.sort = { column: 'reviewDate', ascending: true };
+      req.datatable.schema = getSchema(req.rop);
       next();
     },
     locals: (req, res, next) => {
       // remove empty columns
-      res.locals.datatable.schema = pickBy(schema, (field, key) => {
+      res.locals.datatable.schema = pickBy(req.datatable.schema, (field, key) => {
         return some(req.datatable.data.rows, row => {
           return row[key] !== null;
         });
       });
       next();
     }
-  })({ schema, defaultRowCount: 100 }));
+  })({ defaultRowCount: 100 }));
 
   return app;
 };

--- a/pages/rops/procedures/list/schema/index.js
+++ b/pages/rops/procedures/list/schema/index.js
@@ -1,100 +1,115 @@
 const { get } = require('lodash');
-const { yn, formatSpecies } = require('../formatters');
+const { yn, formatSpecies, getOtherValue } = require('../formatters');
 const content = require('../../content');
 
-const radioOption = field => v => {
+const radioOption = field => (v, rop) => {
   if (!v) {
     return '-';
   }
-  return get(content, `fields.${field}.options.${v}.label`) || get(content, `fields.${field}.options.${v}`) || v;
-};
 
-const schema = {
-  species: {
-    show: true,
-    label: 'Animal species',
-    toCSVString: formatSpecies
-  },
-  reuse: {
-    show: true,
-    label: 'Reuse',
-    toCSVString: yn
-  },
-  placesOfBirth: {
-    show: true,
-    label: 'Place of birth',
-    toCSVString: radioOption('placesOfBirth')
-  },
-  nhpsOrigin: {
-    show: true,
-    label: 'NHP origin',
-    toCSVString: radioOption('nhpsOrigin')
-  },
-  nhpsColonyStatus: {
-    show: true,
-    label: 'NHP colony status',
-    toCSVString: radioOption('nhpsColonyStatus')
-  },
-  nhpsGeneration: {
-    show: true,
-    label: 'NHP generation',
-    toCSVString: radioOption('nhpsGeneration')
-  },
-  ga: {
-    show: true,
-    label: 'Genetic status',
-    toCSVString: radioOption('ga')
-  },
-  newGeneticLine: {
-    show: true,
-    label: 'New genetic line',
-    toCSVString: yn
-  },
-  purposes: {
-    show: true,
-    label: 'Purpose',
-    toCSVString: radioOption('purposes')
-  },
-  subpurpose: {
-    show: true,
-    sortable: false,
-    label: 'Subpurpose',
-    toCSVString: (value, row) => {
-      switch (row.purposes) {
-        case 'basic':
-          return radioOption('basicSubpurposes')(row.basicSubpurposes);
-        case 'regulatory':
-          return radioOption('regulatorySubpurposes')(row.regulatorySubpurposes);
-        case 'translational':
-          return radioOption('translationalSubpurposes')(row.translationalSubpurposes);
-        default:
-          return '-';
-      }
+  const label = get(content, `fields.${field}.options.${v}.label`) || get(content, `fields.${field}.options.${v}`) || v;
+
+  if (field === 'regulatorySubpurposes' && v.includes('other')) {
+    const otherValue = getOtherValue(v, rop);
+
+    if (otherValue) {
+      return `${label}: ${otherValue}`;
     }
-  },
-  regulatoryLegislation: {
-    show: true,
-    label: 'Regulatory legislation',
-    toCSVString: radioOption('regulatoryLegislation')
-  },
-  severity: {
-    show: true,
-    label: 'Severity',
-    toCSVString: radioOption('severity')
-  },
-  severityNum: {
-    show: true,
-    label: 'Number of procedures'
-  },
-  severityHoNote: {
-    show: true,
-    label: 'Comment for Home Office'
   }
+
+  return label;
 };
 
-// use same label for csv column headings
-Object.keys(schema).forEach(key => {
-  schema[key].title = schema[key].label;
-});
+const getSchema = rop => {
+  const schema = {
+    species: {
+      show: true,
+      label: 'Animal species',
+      toCSVString: formatSpecies
+    },
+    reuse: {
+      show: true,
+      label: 'Reuse',
+      toCSVString: yn
+    },
+    placesOfBirth: {
+      show: true,
+      label: 'Place of birth',
+      toCSVString: radioOption('placesOfBirth')
+    },
+    nhpsOrigin: {
+      show: true,
+      label: 'NHP origin',
+      toCSVString: radioOption('nhpsOrigin')
+    },
+    nhpsColonyStatus: {
+      show: true,
+      label: 'NHP colony status',
+      toCSVString: radioOption('nhpsColonyStatus')
+    },
+    nhpsGeneration: {
+      show: true,
+      label: 'NHP generation',
+      toCSVString: radioOption('nhpsGeneration')
+    },
+    ga: {
+      show: true,
+      label: 'Genetic status',
+      toCSVString: radioOption('ga')
+    },
+    newGeneticLine: {
+      show: true,
+      label: 'New genetic line',
+      toCSVString: yn
+    },
+    purposes: {
+      show: true,
+      label: 'Purpose',
+      toCSVString: radioOption('purposes')
+    },
+    subpurpose: {
+      show: true,
+      sortable: false,
+      label: 'Subpurpose',
+      toCSVString: (value, row) => {
+        switch (row.purposes) {
+          case 'basic':
+            return radioOption('basicSubpurposes')(row.basicSubpurposes);
+          case 'regulatory':
+            return radioOption('regulatorySubpurposes')(row.regulatorySubpurposes, rop);
+          case 'translational':
+            return radioOption('translationalSubpurposes')(row.translationalSubpurposes);
+          default:
+            return '-';
+        }
+      }
+    },
+    regulatoryLegislation: {
+      show: true,
+      label: 'Regulatory legislation',
+      toCSVString: radioOption('regulatoryLegislation')
+    },
+    severity: {
+      show: true,
+      label: 'Severity',
+      toCSVString: radioOption('severity')
+    },
+    severityNum: {
+      show: true,
+      label: 'Number of procedures'
+    },
+    severityHoNote: {
+      show: true,
+      label: 'Comment for Home Office'
+    }
+  };
 
-module.exports = schema;
+  // use same label for csv column headings
+  Object.keys(schema).forEach(key => {
+    schema[key].title = schema[key].label;
+  });
+
+  return schema;
+};
+
+module.exports = getSchema;

--- a/pages/rops/procedures/list/views/index.jsx
+++ b/pages/rops/procedures/list/views/index.jsx
@@ -65,8 +65,9 @@ const Submission = () => {
 };
 
 export default function Procedures() {
-  const hasProcedures = useSelector(state => !!state.static.rop.procedures.length);
-  const editable = useSelector(state => state.static.rop.status === 'draft');
+  const rop = useSelector(state => state.static.rop);
+  const hasProcedures = !!rop.procedures.length;
+  const editable = rop.status === 'draft';
 
   return (
     <Fragment>
@@ -101,7 +102,7 @@ export default function Procedures() {
         hasProcedures
           ? (
             <OverflowWrapper>
-              <Datatable formatters={formatters} Actions={editable && Actions} />
+              <Datatable formatters={formatters(rop)} Actions={editable && Actions} />
             </OverflowWrapper>
           )
           : <p><em>No procedures added</em></p>

--- a/pages/rops/update/views/components/confirm.jsx
+++ b/pages/rops/update/views/components/confirm.jsx
@@ -221,6 +221,15 @@ export default function Confirm() {
                                 {
                                   sub === 'routine-other' && <Inset>{rop.regulatorySubpurposesOther}</Inset>
                                 }
+                                {
+                                  sub === 'other-efficacy' && <Inset>{rop.regulatorySubpurposesOtherEfficacy}</Inset>
+                                }
+                                {
+                                  sub === 'other-toxicity' && <Inset>{rop.regulatorySubpurposesOtherToxicity}</Inset>
+                                }
+                                {
+                                  sub === 'other-toxicity-ecotoxicity' && <Inset>{rop.regulatorySubpurposesOtherToxicityEcotoxicity}</Inset>
+                                }
                               </li>
                             ))
                           }


### PR DESCRIPTION
Display the free text entered by the user when selecting any of the "other" regulatory sub-purposes.

Note that the ROP data is now passed to the procedures list schema so we can get the "other" values from the ROP. The alternative was to return the same ROP with every row of procedures from the API, which seemed like a lot of unnecessary data transfer.

I recommend hiding whitespace changes for the review.