### PR TITLE
Fix deadline passed content

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -4,6 +4,7 @@ const { get, isEqual, mapValues, isPlainObject, omit, castArray, reduce, isUndef
 const { parse } = require('url');
 const qs = require('qs');
 const striptags = require('striptags');
+const { dateFormat } = require('../../constants');
 
 const toTitleCase = str =>
   str.replace(/\w\S*/g, txt => `${txt.charAt(0).toUpperCase()}${txt.substr(1)}`);
@@ -126,7 +127,7 @@ const canTransferPil = ({ pil, user }) => {
     });
 };
 
-const formatDate = (date, format) => date ? dateFormatter(date, format) : '-';
+const formatDate = (date, format = dateFormat.medium) => date ? dateFormatter(date, format) : '-';
 
 const daysSinceDate = (date, from = new Date()) => differenceInDays(from, date);
 

--- a/pages/task/read/content/deadline-passed.js
+++ b/pages/task/read/content/deadline-passed.js
@@ -5,10 +5,7 @@ module.exports = merge({}, baseContent, {
   deadline: {
     passed: {
       title: 'Confirm reason for statutory deadline passing',
-      summary: {
-        singular: 'This application is {{days}} day after the deadline for when a decision was due. Confirm the reason so ASRU can record if it\'s a justified delay.',
-        plural: 'This application is {{days}} days after the deadline for when a decision was due. Confirm the reason so ASRU can record if it\'s a justified delay.'
-      }
+      summary: 'A decision about this application was due on {{date}}. Confirm why the deadline was missed so ASRU can record if it\'s a justified delay.'
     }
   },
   fields: {

--- a/pages/task/read/routers/deadline-passed.js
+++ b/pages/task/read/routers/deadline-passed.js
@@ -7,6 +7,7 @@ module.exports = () => {
 
   app.use((req, res, next) => {
     req.model = { id: req.task.id };
+    res.locals.static.task = req.task;
     next();
   });
 

--- a/pages/task/read/views/deadline-passed.jsx
+++ b/pages/task/read/views/deadline-passed.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import { Form, Snippet, Header } from '@asl/components';
+import { formatDate } from '../../../../lib/utils';
 
 export default function DeadlinePassedReason() {
   const task = useSelector(state => state.static.task);
-  const daysSinceDeadline = get(task, 'data.deadline.daysSince');
+  const deadline = get(task, 'data.deadline');
+  const deadlineDate = deadline.isExtended ? deadline.extended : deadline.standard;
 
   return (
     <div className="govuk-grid-row">
@@ -13,7 +15,7 @@ export default function DeadlinePassedReason() {
         <Form>
           <Header title={<Snippet>deadline.passed.title</Snippet>} />
           <p>
-            <Snippet days={daysSinceDeadline}>{`deadline.passed.summary.${daysSinceDeadline > 1 ? 'plural' : 'singular'}`}</Snippet>
+            <Snippet date={formatDate(deadlineDate)}>deadline.passed.summary</Snippet>
           </p>
         </Form>
       </div>


### PR DESCRIPTION
* Pass the task in the page params so that the deadline metadata is accessible
* Update the content
* Add a default date format so only one wild require path is needed to do a date formatting