### PR TITLE
Use project title in favour of modelData on project submission pages

### DIFF
--- a/pages/success/index.js
+++ b/pages/success/index.js
@@ -85,7 +85,7 @@ const getSuccessType = task => {
   return task.status;
 };
 
-const getAdditionalInfo = task => {
+const getAdditionalInfo = ({ task, project }) => {
   const model = get(task, 'data.model');
 
   switch (model) {
@@ -100,7 +100,7 @@ const getAdditionalInfo = task => {
       return get(task, 'data.modelData.name');
 
     case 'project':
-      return get(task, 'data.modelData.title');
+      return get(project, 'title') || get(task, 'data.modelData.title');
 
     case 'profile':
       return get(task, 'data.modelData.name');
@@ -136,7 +136,7 @@ module.exports = () => {
     res.locals.static.establishment = req.establishment || get(req.task, 'data.establishment');
     res.locals.static.taskIsOpen = get(req.task, 'isOpen');
     res.locals.static.isAsruUser = req.user.profile.asruUser;
-    res.locals.static.additionalInfo = getAdditionalInfo(req.task);
+    res.locals.static.additionalInfo = getAdditionalInfo(req);
 
     next();
   });


### PR DESCRIPTION
Since the title is liable to change from the original model data through the task lifecycle, use the project title as a preference rather than the modelData value to ensure it is up to date if the title is changed during an iteration.