### PR TITLE
Add default value to species validator

### DIFF
--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -44,7 +44,7 @@ module.exports = req => {
         validate: [
           {
             customValidate: val => {
-              return !!flatten(Object.values(val)).length;
+              return !!flatten(Object.values(val || {})).length;
             }
           }
         ]


### PR DESCRIPTION
Without a default value then it is not possible to return to a legacy project ROP if it was abandoned at the species selector step because it throws an error trying to call `Object.values(undefined)`.