### PR TITLE
Default array before reading length

### DIFF
--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -48,7 +48,7 @@ module.exports = req => {
                 return false;
               }
               const others = val.precoded.filter(s => s.includes('other-'));
-              return every(others, key => val[`species-${key}`].length);
+              return every(others, key => (val[`species-${key}`] || []).length);
             }
           }
         ]


### PR DESCRIPTION
If the species free-text field is never interacted with, then the value is undefined rather than an empty array, which causes an error if you attempt to read the length.