### PR TITLE
Always include currently viewed version in list of available versions

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -17,8 +17,8 @@ const getVersion = () => (req, res, next) => {
         openTasks: meta.openTasks,
         ...req.project
       };
-      req.project.versions = req.project.versions.filter(canViewVersion(req.user));
-      req.project.retrospectiveAssessments = req.project.retrospectiveAssessments.filter(canViewVersion(req.user));
+      req.project.versions = req.project.versions.filter(canViewVersion(req));
+      req.project.retrospectiveAssessments = req.project.retrospectiveAssessments.filter(canViewVersion(req));
       req.version = data;
     })
     .then(() => next())
@@ -137,8 +137,8 @@ const getNode = (tree, path) => {
   return node;
 };
 
-const canViewVersion = user => version => {
-  return (user.profile.asruUser === version.asruVersion) || version.status !== 'draft';
+const canViewVersion = req => version => {
+  return (req.user.profile.asruUser === version.asruVersion) || version.status !== 'draft' || version.id === req.versionId;
 };
 
 const getFirstVersion = (req, type = 'project-versions') => {


### PR DESCRIPTION
If an ASRU users is looking at a draft PPL version which is currently with the applicant then that version is not included in the set of available versions for comparison, which causes errors to be thrown because the right versions cannot be found.

Always include the version currently on screen in the set of available versions so that the numebr of iterations makes sense when looking at the most recent draft version of a returned PPL application.