### PR TITLE
Render disabled button if user cannot be removed from an establishment

### DIFF
--- a/pages/profile/permission/views/index.jsx
+++ b/pages/profile/permission/views/index.jsx
@@ -56,11 +56,15 @@ export default function Page() {
           }
         </p>
         <p>
-          <Link
-            className="govuk-button button-warning"
-            page="profile.remove"
-            label={<Snippet>buttons.remove</Snippet>}
-          />
+          {
+            nonRemovable
+              ? <Button disabled={true} className="button-warning"><Snippet>buttons.remove</Snippet></Button>
+              : <Link
+                className="govuk-button button-warning"
+                page="profile.remove"
+                label={<Snippet>buttons.remove</Snippet>}
+              />
+          }
         </p>
         <p>
           <Link


### PR DESCRIPTION
Adding a disabled prop to the link doesn't change its behaviour - if the user clicks on the disabled link they are still taken to the remove page.

Instead of the link, render a disabled button when the functionality is required to be switched off.