### PR TITLE
Remove double margin from ULs in DDs

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -86,6 +86,10 @@ dl.continuation {
     }
     dd {
       margin-left: 50%;
+
+      ul {
+        margin-bottom: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
The whitespace on definition lists looks a bit wonky if there are ULs in it as the last item, as both the UL and the DD have margin-bottom that adds up.
