### PR TITLE
Optimise data payloads for ROPs

### DIFF
--- a/pages/rops/components/header.jsx
+++ b/pages/rops/components/header.jsx
@@ -6,7 +6,8 @@ import { dateFormat } from '../../../constants';
 import ProceduresDownloadLink from './procedures-download-link';
 
 export default function RopHeader() {
-  const { project, establishment } = useSelector(state => state.static);
+  const establishment = useSelector(state => state.static.establishment);
+  const project = useSelector(state => state.model.project);
 
   return (
     <DocumentHeader

--- a/pages/rops/components/procedures-download-link.jsx
+++ b/pages/rops/components/procedures-download-link.jsx
@@ -4,7 +4,9 @@ import { Link } from '@asl/components';
 import format from 'date-fns/format';
 
 export default function ProceduresDownloadLink({ className }) {
-  const { project, year } = useSelector(state => state.static);
+  const year = useSelector(state => state.static.year);
+  const project = useSelector(state => state.model.project);
+
   const now = format(new Date(), 'DD-MM-YYYY');
   const filename = `procedures-added-to-rop-for-${project.licenceNumber}-in-${year}-downloaded-${now}.csv`;
 

--- a/pages/rops/helpers.js
+++ b/pages/rops/helpers.js
@@ -24,7 +24,13 @@ function hasGeneticallyAltered(req) {
   return get(req.project, 'granted.data.ga', false);
 }
 
+function hasOtherSpecies(req) {
+  return (get(req.project, 'granted.data.species-other') || []).length ||
+    (get(req.project, 'granted.data.species') || []).find(s => s.includes('other'));
+}
+
 module.exports = {
   hasNhps,
-  hasGeneticallyAltered
+  hasGeneticallyAltered,
+  hasOtherSpecies
 };

--- a/pages/rops/index.js
+++ b/pages/rops/index.js
@@ -1,5 +1,7 @@
 const { Router } = require('express');
+const { get, omit, pick } = require('lodash');
 const routes = require('./routes');
+const { hasNhps, hasGeneticallyAltered, hasOtherSpecies } = require('./helpers');
 
 module.exports = () => {
   const app = Router();
@@ -11,18 +13,28 @@ module.exports = () => {
         req.project = req.rop.project;
         req.version = req.rop.project.granted;
         req.establishment = meta.establishment;
-        Object.assign(res.locals.static, {
-          rop: req.rop,
-          project: req.rop.project
-        });
       })
       .then(() => next())
       .catch(next);
   });
 
   app.use((req, res, next) => {
+    res.locals.static.hasNhps = hasNhps(req);
+    res.locals.static.hasGeneticallyAltered = hasGeneticallyAltered(req);
+    res.locals.static.hasEndangeredSpecies = get(req.project, 'granted.data.endangered-animals', false);
+    res.locals.static.hasReUse = get(req.project, 'granted.data.reuse', false);
+    res.locals.static.species = get(req.project, 'granted.data.species', []);
+    res.locals.static.hasOtherSpecies = hasOtherSpecies(req);
+    next();
+  });
+
+  app.use((req, res, next) => {
     req.model = req.rop;
+    // remove full project data from payload sent to the client
+    req.model.project = omit(req.model.project, 'granted');
     res.locals.static.year = `${(new Date()).getFullYear()}`;
+    res.locals.static.project = pick(req.model.project, 'title');
+    res.locals.model = req.model;
     next();
   });
 

--- a/pages/rops/nil-return/views/index.jsx
+++ b/pages/rops/nil-return/views/index.jsx
@@ -6,7 +6,8 @@ import Header from '../../components/header';
 import { Snippet, Link, WidthContainer } from '@asl/components';
 
 export default function NilReturn() {
-  const { project, rop } = useSelector(state => state.static);
+  const rop = useSelector(state => state.model);
+  const project = rop.project;
 
   const noProcs = rop.proceduresCompleted === false;
 

--- a/pages/rops/procedures/list/index.js
+++ b/pages/rops/procedures/list/index.js
@@ -39,5 +39,7 @@ module.exports = () => {
     }
   })());
 
+  app.get('/', (req, res) => res.sendResponse());
+
   return app;
 };

--- a/pages/rops/procedures/list/views/index.jsx
+++ b/pages/rops/procedures/list/views/index.jsx
@@ -23,7 +23,8 @@ function Actions({ model }) {
 }
 
 const Submission = () => {
-  const { url, canSubmit, rop } = useSelector(state => state.static, shallowEqual);
+  const { url, canSubmit } = useSelector(state => state.static, shallowEqual);
+  const rop = useSelector(state => state.model);
   const hasProcedures = !!rop.procedures.length;
   const editable = rop.status === 'draft';
 
@@ -61,7 +62,7 @@ const Submission = () => {
 };
 
 export default function Procedures() {
-  const rop = useSelector(state => state.static.rop);
+  const rop = useSelector(state => state.model);
   const hasProcedures = !!rop.procedures.length;
   const editable = rop.status === 'draft';
 

--- a/pages/rops/procedures/schema/index.js
+++ b/pages/rops/procedures/schema/index.js
@@ -209,7 +209,7 @@ function getPurposes(req) {
 }
 
 module.exports = (req, addMultiple) => {
-  const projectSpecies = (get(req, 'rop.project.granted.data.species') || []).filter(s => !s.includes('other'));
+  const projectSpecies = (get(req, 'project.granted.data.species') || []).filter(s => !s.includes('other'));
   const ropSpecies = flatten(Object.values(get(req, 'rop.species') || {})).filter(s => !s.match(/^other-/));
 
   const hasGa = get(req, 'rop.ga', false);

--- a/pages/rops/submit/views/confirm.jsx
+++ b/pages/rops/submit/views/confirm.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Snippet, Header, FormLayout } from '@asl/components';
 
 export default function Submit() {
-  const project = useSelector(state => state.static.project);
+  const project = useSelector(state => state.model.project);
   return (
     <FormLayout cancelLink="rops.procedures">
       <Header

--- a/pages/rops/submit/views/index.jsx
+++ b/pages/rops/submit/views/index.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Snippet, Header, FormLayout } from '@asl/components';
 
 export default function Submit() {
-  const project = useSelector(state => state.static.project);
+  const project = useSelector(state => state.model.project);
   return (
     <FormLayout cancelLink="rops.procedures">
       <Header

--- a/pages/rops/update/index.js
+++ b/pages/rops/update/index.js
@@ -2,16 +2,9 @@ const { page } = require('@asl/service/ui');
 const { multiStep } = require('../../common/routers');
 const config = require('./config');
 const schema = require('./schema');
-const { hasNhps, hasGeneticallyAltered } = require('../helpers');
 
 module.exports = () => {
   const app = page({ root: __dirname });
-
-  app.use((req, res, next) => {
-    res.locals.static.hasNhps = hasNhps(req);
-    res.locals.static.hasGeneticallyAltered = hasGeneticallyAltered(req);
-    next();
-  });
 
   app.use(multiStep({
     config,

--- a/pages/rops/update/views/components/confirm.jsx
+++ b/pages/rops/update/views/components/confirm.jsx
@@ -21,7 +21,7 @@ function yn(val) {
 const ALL_SPECIES = flatten(values(projectSpecies));
 
 function Section({ title, children, step }) {
-  const editable = useSelector(state => state.static.rop.status) === 'draft';
+  const editable = useSelector(state => state.model.status) === 'draft';
   return (
     <Fragment>
       <hr />
@@ -42,8 +42,8 @@ function Section({ title, children, step }) {
 }
 
 export default function Confirm() {
-  const { year, rop, hasNhps } = useSelector(state => state.static);
-  const projSpecies = get(rop, 'project.granted.data.species') || [];
+  const { year, hasNhps, species: projSpecies } = useSelector(state => state.static);
+  const rop = useSelector(state => state.model);
   const ropSpecies = get(rop, 'species.precoded') || [];
   const otherSpecies = get(rop, 'species.otherSpecies') || [];
 

--- a/pages/rops/update/views/components/endandered.jsx
+++ b/pages/rops/update/views/components/endandered.jsx
@@ -1,11 +1,9 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import get from 'lodash/get';
 import { Snippet } from '@asl/components';
 
 export default function Endangered() {
-  const project = useSelector(state => state.static.project);
-  const endangered = get(project, 'granted.data.endangered-animals', false);
+  const endangered = useSelector(state => state.static.hasEndangeredSpecies);
   return (
     <Fragment>
       <h3><Snippet>playback</Snippet></h3>

--- a/pages/rops/update/views/components/reuse.jsx
+++ b/pages/rops/update/views/components/reuse.jsx
@@ -1,11 +1,9 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import get from 'lodash/get';
 import { Snippet } from '@asl/components';
 
 export default function Reuse() {
-  const project = useSelector(state => state.static.project);
-  const reuse = get(project, 'granted.data.reuse', false);
+  const reuse = useSelector(state => state.static.hasReUse);
   return (
     <Fragment>
       <h3><Snippet>playback</Snippet></h3>

--- a/pages/rops/update/views/components/schedule2.jsx
+++ b/pages/rops/update/views/components/schedule2.jsx
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 import { Snippet, Details, Inset } from '@asl/components';
 
 export default function Schedule2() {
-  const rop = useSelector(state => state.static.rop);
+  const rop = useSelector(state => state.model);
   const placesOfBirth = get(rop, 'placesOfBirth') || [];
   return (
     <Fragment>

--- a/pages/rops/update/views/components/species.jsx
+++ b/pages/rops/update/views/components/species.jsx
@@ -1,17 +1,13 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import get from 'lodash/get';
 import { Snippet } from '@asl/components';
 import ReviewField from '@asl/projects/client/components/review-field';
 
 export default function Species() {
-  const project = useSelector(state => state.static.project);
-  const data = project.granted.data;
+  const { schemaVersion } = useSelector(state => state.model.project);
+  const { hasOtherSpecies, species } = useSelector(state => state.static);
 
-  const hasOtherSpecies = (get(data, 'species-other') || []).length ||
-    (get(data, 'species') || []).find(s => s.includes('other'));
-
-  if (project.schemaVersion === 0 || hasOtherSpecies) {
+  if (schemaVersion === 0 || hasOtherSpecies) {
     return null;
   }
 
@@ -20,7 +16,7 @@ export default function Species() {
       <h3><Snippet>playback</Snippet></h3>
       <p><Snippet>fields.species.playback</Snippet></p>
       <ReviewField
-        project={{ species: data.species }}
+        project={{ species }}
         type="species-selector"
       />
     </Fragment>

--- a/pages/rops/update/views/index.jsx
+++ b/pages/rops/update/views/index.jsx
@@ -6,7 +6,7 @@ import formatters from '../formatters';
 import components from './components';
 
 export default function Step() {
-  const { step, project, schema } = useSelector(state => state.static);
+  const { step, schema, project } = useSelector(state => state.static);
   const Component = components[step];
   return (
     <FormLayout formatters={pick(formatters, Object.keys(schema || {}))}>


### PR DESCRIPTION
The complete version data is being included in three different places in `INITIAL_STATE` which causes very slow load times for large projects.

None of these need to be sent if we move the basic calculations being done on the client to the server and send calculated props as required.

Also remove duplication of `state.model` and `state.static.rop` to further reduce redundant data in the payload.