### PR TITLE
Fix props for ROP submission

### DIFF
--- a/pages/rops/components/header.jsx
+++ b/pages/rops/components/header.jsx
@@ -6,8 +6,8 @@ import { dateFormat } from '../../../constants';
 import ProceduresDownloadLink from './procedures-download-link';
 
 export default function RopHeader() {
-  const establishment = useSelector(state => state.static.establishment);
   const project = useSelector(state => state.model.project);
+  const establishment = project.establishment;
 
   return (
     <DocumentHeader

--- a/pages/rops/nil-return/index.js
+++ b/pages/rops/nil-return/index.js
@@ -19,5 +19,7 @@ module.exports = () => {
       .catch(next);
   });
 
+  app.get('/', (req, res) => res.sendResponse());
+
   return app;
 };

--- a/pages/rops/submit/index.js
+++ b/pages/rops/submit/index.js
@@ -16,5 +16,7 @@ module.exports = () => {
 
   app.use('/success', success());
 
+  app.get('*', (req, res) => res.sendResponse());
+
   return app;
 };


### PR DESCRIPTION
* Prevent router falling through to project router and overwriting `res.locals.model`.
* Read establishment data from project to get around inconsistency with `static.establishment` existing in some places but not others.