### PR TITLE
Fix check for GAAs on new style PPLs

### DIFF
--- a/pages/rops/helpers.js
+++ b/pages/rops/helpers.js
@@ -16,12 +16,12 @@ function hasNhps(req, option) {
 }
 
 function hasGeneticallyAltered(req) {
-  if (req.project.schemaVersion === 0) {
-    return (get(req.project, 'granted.data.protocols') || []).some(protocol => {
+  return (get(req.project, 'granted.data.protocols') || []).some(protocol => {
+    if (req.project.schemaVersion === 0) {
       return (protocol.species || []).some(s => s['genetically-altered']);
-    });
-  }
-  return get(req.project, 'granted.data.ga', false);
+    }
+    return protocol.gaas;
+  });
 }
 
 function hasOtherSpecies(req) {


### PR DESCRIPTION
This was looking for a `ga` flag on the version data, which does not seem to exist. Check each protocol for the `gaas` field.