### PR TITLE
Use permissions service to determine stub conversion permissions

### DIFF
--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -135,7 +135,7 @@ export default function Profile({ profile, establishment = {}, allowedActions = 
 
             <div className="control-panel float-right">
               {
-                allowedActions.includes('project.convertLegacy') &&
+                allowedActions.includes('project.stub.create') &&
                   <Link
                     className="govuk-button button-secondary"
                     page="profile.convertLegacyProject"

--- a/pages/profile/routes.js
+++ b/pages/profile/routes.js
@@ -29,7 +29,7 @@ module.exports = {
   },
   convertLegacyProject: {
     path: '/:profileId/convert-legacy-project',
-    permissions: 'project.convertLegacy',
+    permissions: 'project.stub.create',
     router: convertLegacyProject
   },
   invite: {

--- a/pages/project/read/index.js
+++ b/pages/project/read/index.js
@@ -35,6 +35,7 @@ module.exports = settings => {
     };
     Promise.all([
       req.user.can('project.update', params),
+      req.user.can('project.stub.update', params),
       req.user.can('project.revoke', params),
       req.user.can('project.transfer', params),
       req.user.can('project.manageAccess', params),
@@ -42,7 +43,7 @@ module.exports = settings => {
       req.user.can('project.rops.create', params),
       req.user.can('retrospectiveAssessment.update', params)
     ])
-      .then(([canUpdate, canRevoke, canTransfer, canManageAccess, canUpdateRops, canCreateRops, canUpdateRa]) => {
+      .then(([canUpdate, canUpdateStub, canRevoke, canTransfer, canManageAccess, canUpdateRops, canCreateRops, canUpdateRa]) => {
         const openTasks = req.project.openTasks;
         const openTask = openTasks && openTasks.find(t => t.data.action !== 'grant-ra');
         const openRaTask = openTasks && openTasks.find(t => t.data.action === 'grant-ra');
@@ -55,6 +56,7 @@ module.exports = settings => {
         res.locals.static.canUpdateRa = canUpdateRa;
         res.locals.static.canManageAccess = canManageAccess;
         res.locals.static.canUpdate = canUpdate && isCorrectEstablishment;
+        res.locals.static.canUpdateStub = canUpdateStub;
         res.locals.static.showReporting = isCorrectEstablishment && canAccessRops && req.project.status !== 'inactive';
         res.locals.static.canTransfer = canTransfer;
         res.locals.static.editable = editable;
@@ -62,7 +64,6 @@ module.exports = settings => {
         res.locals.static.openRaTask = openRaTask;
         res.locals.static.canRevoke = canRevoke;
         res.locals.static.asruUser = req.user.profile.asruUser;
-        res.locals.static.asruLicensing = req.user.profile.asruLicensing;
         res.locals.static.showManageSection = canUpdate || canRevoke || canTransfer || canManageAccess;
         res.locals.static.removeUserUrl = req.buildRoute('project.removeUser');
       })

--- a/pages/project/read/views/components/amend-stub.jsx
+++ b/pages/project/read/views/components/amend-stub.jsx
@@ -6,9 +6,9 @@ import Subsection from './subsection';
 
 export default function AmendStub() {
   const project = useSelector(state => state.model);
-  const { asruLicensing, canUpdate, additionalAvailability } = useSelector(state => state.static);
+  const { canUpdateStub, additionalAvailability } = useSelector(state => state.static);
 
-  if (!project.isLegacyStub || !asruLicensing || !canUpdate || additionalAvailability) {
+  if (!project.isLegacyStub || !canUpdateStub || additionalAvailability) {
     return null;
   }
 

--- a/pages/project/read/views/components/discard-stub.jsx
+++ b/pages/project/read/views/components/discard-stub.jsx
@@ -14,10 +14,10 @@ const confirmSubmission = message => e => {
 
 export default function DiscardStub() {
   const project = useSelector(state => state.model);
-  const { url, confirmMessage, asruLicensing, canUpdate, additionalAvailability } = useSelector(state => state.static);
+  const { url, confirmMessage, canUpdateStub, additionalAvailability } = useSelector(state => state.static);
 
   // legacy stubs can be discarded at any point
-  if (!project.isLegacyStub || !asruLicensing || !canUpdate || additionalAvailability) {
+  if (!project.isLegacyStub || !canUpdateStub || additionalAvailability) {
     return null;
   }
 

--- a/pages/project/read/views/components/start-amendment.jsx
+++ b/pages/project/read/views/components/start-amendment.jsx
@@ -20,7 +20,7 @@ const confirmSubmission = message => e => {
 
 export default function StartAmendment() {
   const project = useSelector(state => state.model);
-  const { confirmMessage, url, openTask, editable, asruUser, canUpdate, canTransfer, asruLicensing, additionalAvailability } = useSelector(state => state.static);
+  const { confirmMessage, url, openTask, editable, asruUser, canUpdate, canTransfer, canUpdateStub, additionalAvailability } = useSelector(state => state.static);
 
   let startAmendmentDescriptionKey = 'start';
 
@@ -52,7 +52,7 @@ export default function StartAmendment() {
     startAmendmentDescriptionKey = 'transfer';
   }
 
-  const canChangeLicenceHolder = !project.draft && !openTask && canUpdate && project.status === 'active' && (!project.isLegacyStub || (project.isLegacyStub && asruLicensing));
+  const canChangeLicenceHolder = !project.draft && !openTask && canUpdate && project.status === 'active' && (!project.isLegacyStub || (project.isLegacyStub && canUpdateStub));
 
   return (
     <Subsection


### PR DESCRIPTION
These are no longer bound to licensing officers. Move the permissions logic to the permissions service so that if they need to be changed in future then they can be changed once.