### PR TITLE
Only show the relevant declaration questions for each item in the activity log

### DIFF
--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -44,6 +44,10 @@ module.exports = () => {
     if (req.project) {
       req.askAwerb = askAwerb(req.task, status);
       req.awerbEstablishments = [req.project.establishment].concat(req.project.additionalEstablishments);
+
+      get(req.task, 'data.meta[awerb-dates]', []).map(awerb => {
+        req.model[`awerb-${awerb.id}`] = awerb.date;
+      });
     }
     next();
   });


### PR DESCRIPTION
Bonus fix: re-populate the awerb date field on re-endorsement if present.