### PR TITLE
Bugfix - dont try and render null date

### DIFF
--- a/pages/project-version/nts/schema/legacy.js
+++ b/pages/project-version/nts/schema/legacy.js
@@ -38,7 +38,7 @@ module.exports = {
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of these aims will be due by {{raDate}}
+        content: `### A retrospective assessment of these aims will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * Is there a plan for this work to continue under another licence?
   * Did the project achieve it's aims and if not, why not?`
@@ -77,7 +77,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of these predicted harms will be due by {{raDate}}
+        content: `### A retrospective assessment of these predicted harms will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * What harms were caused to the animals, how severe were those harms and how many animals were affected?`
       }
@@ -93,7 +93,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of replacement will be due by {{raDate}}
+        content: `### A retrospective assessment of replacement will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * What, if any, non-animal alternatives were used or explored after the project started, and is there anything others
   can learn from your experience?`
@@ -110,7 +110,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of reduction will be due by {{raDate}}
+        content: `### A retrospective assessment of reduction will be due by {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * How did you minimise the numbers of animals used on your project and is there anything others can learn from your experience?`
       }
@@ -127,7 +127,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of refinement will be due by {{raDate}}
+        content: `### A retrospective assessment of refinement will be due by {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * With the knowledge you have now, could the choice of animals or model(s) used be improved for future work of this kind?
   During the project, how did you minimise harm to the animals?`

--- a/pages/project-version/nts/schema/standard.js
+++ b/pages/project-version/nts/schema/standard.js
@@ -43,7 +43,7 @@ module.exports = {
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of these aims will be due by {{raDate}}
+        content: `### A retrospective assessment of these aims will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * Is there a plan for this work to continue under another licence?
   * Did the project achieve it's aims and if not, why not?`
@@ -132,7 +132,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of these predicted harms will be due by {{raDate}}
+        content: `### A retrospective assessment of these predicted harms will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * What harms were caused to the animals, how severe were those harms and how many animals were affected?`
       }
@@ -166,7 +166,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of replacement will be due by {{raDate}}
+        content: `### A retrospective assessment of replacement will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * What, if any, non-animal alternatives were used or explored after the project started, and is there anything others
   can learn from your experience?`
@@ -215,7 +215,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of reduction will be due by {{raDate}}
+        content: `### A retrospective assessment of reduction will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * How did you minimise the numbers of animals used on your project and is there anything others can learn from your experience?`
       }
@@ -251,7 +251,7 @@ The PPL holder will be required to disclose:
       },
       {
         type: 'RetrospectivePlaceholder',
-        content: `### A retrospective assessment of refinement will be due by {{raDate}}
+        content: `### A retrospective assessment of refinement will be due {{#hasRaDate}}by {{raDate}}{{/hasRaDate}}{{^hasRaDate}}within 6 months of the licence's revocation date{{/hasRaDate}}
 The PPL holder will be required to disclose:
   * With the knowledge you have now, could the choice of animals or model(s) used be improved for future work of this kind?
   During the project, how did you minimise harm to the animals?`

--- a/pages/project-version/nts/views/components/retrospective-placeholder.jsx
+++ b/pages/project-version/nts/views/components/retrospective-placeholder.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import format from 'date-fns/format';
 import { Markdown } from '@asl/components';
 import { dateFormat } from '../../../../../constants';
+import { render } from 'mustache';
 
 export default function RetrospectivePlaceholder({ project, version, field }) {
   const raCompulsory = version.raCompulsory;
@@ -12,7 +13,7 @@ export default function RetrospectivePlaceholder({ project, version, field }) {
     return null;
   }
 
-  const content = field.content.replace('{{raDate}}', format(project.raDate, dateFormat.long));
+  const content = render(field.content, { raDate: format(project.raDate, dateFormat.long), hasRaDate: !!project.raDate });
 
   return (
     <div className="retrospective-placeholder">


### PR DESCRIPTION
* If ra is added to a submitted draft and the nts printed before approval, raDate is null
* in this case render standard 6 month content rather than 1970
* Replaced mustache-like-code with mustache