### PR TITLE
Bugfix - rop nil return logic

### DIFF
--- a/pages/common/routers/multi-step.js
+++ b/pages/common/routers/multi-step.js
@@ -71,6 +71,15 @@ module.exports = ({ schema, config, root, postData = (req, res, next) => next() 
     }, null);
 
     if (redirectStep) {
+      const prevStep = allSteps[allSteps.indexOf(redirectStep) - 1];
+      if (prevStep) {
+        const prevStepConfig = config[prevStep];
+        const target = prevStepConfig.target && prevStepConfig.target(req);
+        if (target) {
+          return res.redirect(target);
+        }
+      }
+
       return res.redirect(req.buildRoute(root, { step: redirectStep }));
     }
     next();

--- a/pages/rops/update/config.js
+++ b/pages/rops/update/config.js
@@ -46,24 +46,24 @@ const hasPurpose = purpose => req => {
   return purposes.includes(purpose);
 };
 
+function redirectIfNilReturn(req) {
+  const noProceduresCompleted = get(req, 'form.values.proceduresCompleted', req.rop.proceduresCompleted) === false;
+  const noPostnatal = get(req, 'form.values.postnatal', req.rop.postnatal) === false;
+  if (noPostnatal || noProceduresCompleted) {
+    return req.buildRoute('rops.nil-return');
+  }
+}
+
 module.exports = {
   procedures: {
     fields: ['proceduresCompleted'],
     section: 'details',
-    target: req => {
-      if (!req.form.values.proceduresCompleted) {
-        return req.buildRoute('rops.nil-return');
-      }
-    }
+    target: redirectIfNilReturn
   },
   postnatal: {
     fields: ['postnatal'],
     section: 'details',
-    target: req => {
-      if (!req.form.values.postnatal) {
-        return req.buildRoute('rops.nil-return');
-      }
-    }
+    target: redirectIfNilReturn
   },
   endangered: {
     fields: ['endangered', 'endangeredDetails'],


### PR DESCRIPTION
If a nil-return is triggered then journey abandonned, the logic to determine which step the user should be redirected to doesn't take target into account.

* Updated logic for nil return to redirect if either condition is true
* Updated multi-step router logic to apply target function of previous step if present