### PR TITLE
Don't show ROPs tab for projects left behind following a transfer

### DIFF
--- a/pages/project/read/index.js
+++ b/pages/project/read/index.js
@@ -52,12 +52,13 @@ module.exports = settings => {
         const isCorrectEstablishment = req.establishmentId === req.project.establishmentId;
         const ropExists = req.project.rops.length;
         const canAccessRops = ropExists ? canUpdateRops : canCreateRops;
+        const showReporting = isCorrectEstablishment && canAccessRops && (!['inactive', 'transferred'].includes(req.project.status));
 
         res.locals.static.canUpdateRa = canUpdateRa;
         res.locals.static.canManageAccess = canManageAccess;
         res.locals.static.canUpdate = canUpdate && isCorrectEstablishment;
         res.locals.static.canUpdateStub = canUpdateStub;
-        res.locals.static.showReporting = isCorrectEstablishment && canAccessRops && req.project.status !== 'inactive';
+        res.locals.static.showReporting = showReporting;
         res.locals.static.canTransfer = canTransfer;
         res.locals.static.editable = editable;
         res.locals.static.openTask = openTask;


### PR DESCRIPTION
The ROP is only applicable to the establishment which holds the licence, so don't show the reporting tab for transferred out projects.