### PR TITLE
force strings to display as strings in CSVs

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -158,7 +158,7 @@ module.exports = ({
           if (value && /[0-9]+/.test(value) && !value.includes('"')) {
             return { value: `="${value}"`, quote: false };
           } else {
-            return { value, quote: false };
+            return value;
           }
         }
       },

--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -154,7 +154,13 @@ module.exports = ({
       bom: true,
       header: true,
       cast: {
-        string: (value) => ({ value: value ? `="${value}"` : `""`, quote: false })
+        string: (value) => {
+          if (value && /[0-9]+/.test(value) && !value.includes('"')) {
+            return { value: `="${value}"`, quote: false };
+          } else {
+            return { value, quote: false };
+          }
+        }
       },
       columns: Object.keys(schema)
         .filter(key => !schema[key].omitFromCSV)

--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -153,6 +153,9 @@ module.exports = ({
     const stringifier = csv({
       bom: true,
       header: true,
+      cast: {
+        string: (value) => ({ value: value ? `="${value}"` : `""`, quote: false })
+      },
       columns: Object.keys(schema)
         .filter(key => !schema[key].omitFromCSV)
         .map(key => ({ key, header: schema[key].title || key }))


### PR DESCRIPTION
Excel and other spreadsheet apps commonly used to open CSVs, try to "helpfully" format strings that vaguely look like numbers as actual numbers which can lead to weird outputs.