### PR TITLE
if other species are present, don't preselect any species

### DIFF
--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -37,7 +37,8 @@ module.exports = req => {
         inputType: 'speciesSelector',
         projectSpecies: true,
         presets: (req.version.data.species || []).find(s => s.includes('other'))
-          ? [] // if any "other" type species, don't preselect anything
+          // don't add species from project if "other" values are selected
+          ? req.rop.procedures.map(p => p.species)
           : [
             ...(req.version.data.species || []),
             ...(req.rop.procedures.map(p => p.species))

--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -36,10 +36,12 @@ module.exports = req => {
       species: {
         inputType: 'speciesSelector',
         projectSpecies: true,
-        presets: [
-          ...(req.version.data.species || []).filter(s => !s.includes('other')),
-          ...(req.rop.procedures.map(p => p.species))
-        ],
+        presets: (req.version.data.species || []).find(s => s.includes('other'))
+          ? [] // if any "other" type species, don't preselect anything
+          : [
+            ...(req.version.data.species || []),
+            ...(req.rop.procedures.map(p => p.species))
+          ],
         format: JSON.parse,
         validate: [
           {


### PR DESCRIPTION
If a project has "other" species, then they must manually select all of the species in the ROPs, we don't pre-select any for them.