### PR TITLE
Bugfix - disabled rop options

### DIFF
--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -8,17 +8,6 @@ module.exports = req => {
       opt = { value: opt };
     }
 
-    if (opt.reveal) {
-      const keys = Object.keys(opt.reveal);
-      const vals = flatten(keys.map(key => req.rop[key]));
-      if (intersection(vals, field).length) {
-        return {
-          ...opt,
-          disabled: true
-        };
-      }
-    }
-
     if (field.includes(opt.value)) {
       return {
         ...opt,


### PR DESCRIPTION
* Updated disabling logic to use parent option, previously this was reverse engineered from the reveal children but has since been updated to use the parent field value