### PR TITLE
check value exists before attempting to use it

### DIFF
--- a/pages/rops/procedures/list/formatters/index.jsx
+++ b/pages/rops/procedures/list/formatters/index.jsx
@@ -99,7 +99,7 @@ const formatters = rop => {
         const value = model[field];
         const label = getRadioOption(field)(value);
 
-        if (value.includes('other')) {
+        if (value && value.includes('other')) {
           const otherId = model.subpurposeOther;
           other = (others.find(v => v.id === otherId) || {}).value;
         }


### PR DESCRIPTION
When attempting to view the submitted ROP for "ROP with procedures" seed, it fails because `value` is undefined.

This is probably bad seed data but we should prevent it from breaking the page.