### PR TITLE
Legacy PPL / PPL transfer AWERB fixes

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -91,7 +91,6 @@ const validators = {
     if (Array.isArray(ext)) {
       return some(ext, e => validators.ext(field, value, e));
     }
-    console.log(field, value, ext);
     const ra = new RegExp(`\\.${ext}$`);
     return every(value, file => file.originalname.match(ra));
   }

--- a/pages/project-version/update/submit/index.js
+++ b/pages/project-version/update/submit/index.js
@@ -70,8 +70,9 @@ module.exports = settings => {
         const includeAwerb = res.locals.static.canEndorse;
         const awerbEstablishments = req.awerbEstablishments;
         const isLegacy = req.project.schemaVersion === 0;
+        const canBeAwerbExempt = isAmendment;
         req.processAwerbDates = includeAwerb && !isLegacy;
-        req.form.schema = getSchema({ isLegacy, isAmendment, isAsru, includeReady, includeAwerb, awerbEstablishments });
+        req.form.schema = getSchema({ isLegacy, isAmendment, isAsru, includeReady, includeAwerb, canBeAwerbExempt, awerbEstablishments });
         next();
       },
       process: (req, res, next) => {

--- a/pages/project-version/update/submit/schema/index.js
+++ b/pages/project-version/update/submit/schema/index.js
@@ -13,7 +13,7 @@ const getDateField = establishmentName => {
   };
 };
 
-const getAwerbQuestion = ({ isLegacy, isAmendment, awerbEstablishments }) => {
+const getAwerbQuestion = ({ isLegacy, canBeAwerbExempt, awerbEstablishments }) => {
   let awerbDateFields = {};
 
   if (isLegacy) {
@@ -32,7 +32,7 @@ const getAwerbQuestion = ({ isLegacy, isAmendment, awerbEstablishments }) => {
     }, {});
   }
 
-  if (!isAmendment) {
+  if (!canBeAwerbExempt) {
     return awerbDateFields;
   }
 
@@ -64,7 +64,7 @@ const getAwerbQuestion = ({ isLegacy, isAmendment, awerbEstablishments }) => {
   };
 };
 
-const getSchema = ({ isLegacy, isAmendment, isAsru, includeReady, includeAwerb, awerbEstablishments }) => {
+const getSchema = ({ isLegacy, isAmendment, isAsru, includeReady, includeAwerb, canBeAwerbExempt, awerbEstablishments }) => {
   let schema = {
     comments: {
       inputType: 'textarea',
@@ -106,7 +106,7 @@ const getSchema = ({ isLegacy, isAmendment, isAsru, includeReady, includeAwerb, 
   // awerb question should always be first if included
   if (includeAwerb) {
     schema = {
-      ...getAwerbQuestion({ isLegacy, isAmendment, awerbEstablishments }),
+      ...getAwerbQuestion({ isLegacy, isAmendment, canBeAwerbExempt, awerbEstablishments }),
       ...schema
     };
   }

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -49,7 +49,9 @@ module.exports = () => {
       return res.redirect(req.buildRoute('task.read'));
     }
     if (req.project) {
+      const isLegacy = req.project.schemaVersion === 0;
       req.askAwerb = askAwerb(req.task, status);
+      req.processAwerbDates = req.askAwerb && !isLegacy;
 
       if (transferWithReceivingEstablishment(req.task)) {
         req.awerbEstablishments = [get(req.task, 'data.establishment')];
@@ -76,7 +78,7 @@ module.exports = () => {
       next();
     },
     process: (req, res, next) => {
-      if (req.askAwerb && req.form.values['awerb-exempt'] !== 'yes') {
+      if (req.askAwerb && req.processAwerbDates && req.form.values['awerb-exempt'] !== 'yes') {
         req.awerbEstablishments.forEach(e => {
           req.form.values[`awerb-${e.id}`] = `${req.body[`awerb-${e.id}-year`]}-${req.body[`awerb-${e.id}-month`]}-${req.body[`awerb-${e.id}-day`]}`;
         });
@@ -84,7 +86,7 @@ module.exports = () => {
       next();
     },
     saveValues: (req, res, next) => {
-      if (req.askAwerb && req.form.values['awerb-exempt'] !== 'yes') {
+      if (req.askAwerb && req.processAwerbDates && req.form.values['awerb-exempt'] !== 'yes') {
         const primaryEstablishment = req.project.establishment;
         req.session.form[req.model.id].values['awerb-dates'] = req.awerbEstablishments.map(e => {
           return { ...pick(e, 'id', 'name'), date: moment(req.form.values[`awerb-${e.id}`], 'YYYY-MM-DD').format('YYYY-MM-DD'), primary: e.id === primaryEstablishment.id };
@@ -133,7 +135,7 @@ module.exports = () => {
         data: values.data,
         meta: {
           ...values.meta,
-          ...pick(values, 'comment', 'restrictions', 'awerb', 'awerb-exempt', 'awerb-dates', 'awerb-no-review-reason', 'deadline-passed-reason', 'ra-awerb-date', 'declaration')
+          ...pick(values, 'comment', 'restrictions', 'awerb', 'awerb-exempt', 'awerb-dates', 'awerb-review-date', 'awerb-no-review-reason', 'deadline-passed-reason', 'ra-awerb-date', 'declaration')
         }
       }
     };

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -30,6 +30,13 @@ const getDeclarationText = (task, values) => {
   }));
 };
 
+const transferWithReceivingEstablishment = task => {
+  const isTransfer = get(task, 'data.action') === 'transfer';
+  const isAwaitingEndorsement = get(task, 'status') === 'awaiting-endorsement';
+  const isWithReceivingEstablishment = get(task, 'data.data.establishmentId') === get(task, 'data.establishmentId');
+  return isTransfer && isAwaitingEndorsement && isWithReceivingEstablishment;
+};
+
 module.exports = () => {
   const app = Router();
 
@@ -43,7 +50,12 @@ module.exports = () => {
     }
     if (req.project) {
       req.askAwerb = askAwerb(req.task, status);
-      req.awerbEstablishments = [req.project.establishment].concat(req.project.additionalEstablishments);
+
+      if (transferWithReceivingEstablishment(req.task)) {
+        req.awerbEstablishments = [get(req.task, 'data.establishment')];
+      } else {
+        req.awerbEstablishments = [req.project.establishment].concat(req.project.additionalEstablishments);
+      }
 
       get(req.task, 'data.meta[awerb-dates]', []).map(awerb => {
         req.model[`awerb-${awerb.id}`] = awerb.date;

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -54,7 +54,7 @@ module.exports = () => {
       req.processAwerbDates = req.askAwerb && !isLegacy;
 
       if (transferWithReceivingEstablishment(req.task)) {
-        req.awerbEstablishments = [get(req.task, 'data.establishment')];
+        req.awerbEstablishments = [get(req.task, 'data.establishment')].concat(req.project.additionalEstablishments);
       } else {
         req.awerbEstablishments = [req.project.establishment].concat(req.project.additionalEstablishments);
       }

--- a/pages/task/read/views/components/ppl-declarations.jsx
+++ b/pages/task/read/views/components/ppl-declarations.jsx
@@ -12,6 +12,7 @@ export default function PplDeclarations({ task }) {
 
   const status = task.status;
   const isAmendment = task.type === 'amendment';
+  const receivingEstablishmentId = get(task, 'data.action') === 'transfer' && get(task, 'data.data.establishmentId');
 
   // prefer the payload for declarations if available as it reflects the status at the time the task was actioned
   const declarations = get(task, 'meta.payload.meta') || get(task, 'data.meta') || {};
@@ -26,7 +27,8 @@ export default function PplDeclarations({ task }) {
 
   const legacyAwerbReviewDate = declarations['awerb-review-date'];
   const primaryAwerb = displayAwerb && declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => awerb.primary)[0];
-  const aaAwerbs = (displayAwerb && (declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => !awerb.primary))) || [];
+  const aaAwerbs = (displayAwerb && (declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => !awerb.primary && awerb.id !== receivingEstablishmentId))) || [];
+  const receivingAwerb = displayAwerb && receivingEstablishmentId && declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => awerb.id === receivingEstablishmentId)[0];
 
   return (
     <div className="declarations">
@@ -61,6 +63,13 @@ export default function PplDeclarations({ task }) {
           <dl className="inline-wide">
             <dt>AWERB review date:</dt>
             <dd>{format(primaryAwerb.date, dateFormat.long)}</dd>
+          </dl>
+      }
+      {
+        receivingAwerb &&
+          <dl className="inline-wide">
+            <dt>{receivingAwerb.name} AWERB review date:</dt>
+            <dd>{format(receivingAwerb.date, dateFormat.long)}</dd>
           </dl>
       }
       {

--- a/pages/task/read/views/components/ppl-declarations.jsx
+++ b/pages/task/read/views/components/ppl-declarations.jsx
@@ -23,9 +23,9 @@ export default function PplDeclarations({ task }) {
     declarations.ready = get(task, 'data.meta.ready');
   }
 
-  const displayAwerb = declarations['awerb-exempt'] !== 'yes';
-
   const legacyAwerbReviewDate = declarations['awerb-review-date'];
+  const displayAwerb = !legacyAwerbReviewDate && declarations['awerb-exempt'] !== 'yes';
+
   const primaryAwerb = displayAwerb && declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => awerb.primary)[0];
   const aaAwerbs = (displayAwerb && (declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => !awerb.primary && awerb.id !== receivingEstablishmentId))) || [];
   const receivingAwerb = displayAwerb && receivingEstablishmentId && declarations['awerb-dates'] && declarations['awerb-dates'].filter(awerb => awerb.id === receivingEstablishmentId)[0];
@@ -61,7 +61,13 @@ export default function PplDeclarations({ task }) {
       {
         primaryAwerb &&
           <dl className="inline-wide">
-            <dt>AWERB review date:</dt>
+            <dt>
+              {
+                (receivingAwerb || aaAwerbs.length)
+                  ? `${primaryAwerb.name} AWERB review date:`
+                  : 'AWERB review date:'
+              }
+            </dt>
             <dd>{format(primaryAwerb.date, dateFormat.long)}</dd>
           </dl>
       }

--- a/pages/task/schema/confirm.js
+++ b/pages/task/schema/confirm.js
@@ -19,11 +19,15 @@ module.exports = ({ task, chosenStatus, isLegacy, awerbEstablishments }) => {
     }
   };
 
-  const isAmendment = ['amendment', 'transfer'].includes(get(task, 'type'));
+  const taskType = get(task, 'type');
+  const isAmendment = taskType === 'amendment';
+  const isTransfer = taskType === 'transfer';
+  const isWithOutgoingEstablishment = task.data.establishmentId === task.data.modelData.establishmentId;
+  const canBeAwerbExempt = isAmendment || (isTransfer && isWithOutgoingEstablishment);
 
   if (askAwerb(task, chosenStatus)) {
     schema = {
-      ...getAwerbQuestion({ isLegacy, isAmendment, awerbEstablishments }),
+      ...getAwerbQuestion({ isLegacy, isAmendment, isTransfer, canBeAwerbExempt, awerbEstablishments }),
       ...schema
     };
   }


### PR DESCRIPTION
This PR fixes two issues:
1. Legacy PPL amendments submitted by non-PELH/HOLCs were not correctly capturing the legacy AWERB text. This should now be captured correctly regardless of who submits the amendment.

2. PPL transfers were not asking the receiving establishment for their AWERB review date. We now force the receiving establishment to enter their AWERB review date (they cannot be exempt) and also add / review any Additional Availability AWERB dates