### PR TITLE
Transfers must be AWERB reviewed by receiving establishment, flip the task flag

### DIFF
--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -127,6 +127,10 @@ module.exports = () => {
   app.post('/', (req, res, next) => {
     const values = req.session.form[req.model.id].values;
 
+    if (transferWithReceivingEstablishment(req.task)) {
+      values['awerb-exempt'] = 'no'; // receiving establishment for transfers can never be 'awerb-exempt'
+    }
+
     const opts = {
       method: 'PUT',
       headers: { 'Content-type': 'application/json' },


### PR DESCRIPTION
If the outgoing establishment for a PPL transfer declares themselves exempt from AWERB review, the `awerb-exempt` flag is set to `yes` on the task.

We don't re-ask the exemption question for the receiving establishment because the AWERB questions are now enforced, so it was never getting set to 'no'. This was causing the "Latest submission" section to render the "no-review-reason" even though the receiving establishment had to fill in the AWERB dates.

This fix sets it to 'no' when the receiving establishment endorses, so that all the AWERB dates are correctly played back in the "Latest submission" section of the task view.