### PR TITLE
Hide hint message on basic sub-purposes for procedures

### DIFF
--- a/pages/rops/procedures/schema/index.js
+++ b/pages/rops/procedures/schema/index.js
@@ -158,6 +158,7 @@ function getPurposes(req) {
             inputType: 'radioGroup',
             automapReveals: true,
             validate: ['required'],
+            hint: false,
             options: basicSubpurposes.map(bs => {
               if (bs === 'other') {
                 return {


### PR DESCRIPTION
The other procedure sub-purpose fields have the hint disabled to avoid saying "Select all that apply" on a radio group. Do this for basic sub-purposes too.