### PR TITLE
Various ROPS fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "10.5.6",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.5.6.tgz",
-      "integrity": "sha1-lgMuQlygmSW/kKJMvEsR9QSAj50=",
+      "version": "10.5.7",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.5.7.tgz",
+      "integrity": "sha1-JVsHyhCUOtK2CM/h/SevHgYr7I4=",
       "requires": {
         "@asl/constants": "^1.0.0",
         "@asl/dictionary": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^10.5.6",
+    "@asl/components": "^10.5.7",
     "@asl/constants": "^1.0.0",
     "@asl/dictionary": "^1.1.5",
     "@asl/projects": "^10.0.7",

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -82,6 +82,7 @@ module.exports = {
       nts: 'Non-technical summary'
     },
     rops: 'Return of procedures {{year}}',
+    ropsReporting: 'Return of procedures {{year}}',
     account: {
       menu: 'Your account',
       update: 'Edit your details',

--- a/pages/rops/procedures/content/index.js
+++ b/pages/rops/procedures/content/index.js
@@ -36,7 +36,7 @@ module.exports = merge({}, { fields, guidance }, {
   },
   submit: {
     title: 'Submit return',
-    content: 'Submit this project\'s completed return of procedures',
+    content: 'Submit this project\'s completed return of procedures.',
     action: 'Submit return',
     'cannot-submit': 'Only the PPL holder or an admin can submit this to the Home Office.'
   },

--- a/pages/rops/procedures/content/index.js
+++ b/pages/rops/procedures/content/index.js
@@ -10,7 +10,7 @@ module.exports = merge({}, { fields, guidance }, {
   },
   procedures: {
     title: 'Procedures',
-    content: 'Add procedures completed in {{year}}',
+    content: 'Add procedures completed in {{year}}.',
     add: 'Add procedures'
   },
   fields: {

--- a/pages/rops/procedures/index.js
+++ b/pages/rops/procedures/index.js
@@ -29,7 +29,6 @@ module.exports = () => {
     req.api(`/establishment/${req.establishmentId}/project/${req.projectId}/rop/${req.ropId}/unsubmit`, params)
       .then(() => {
         set(res.locals, 'static.content.notifications', content.notifications);
-        req.notification({ key: 'success' });
         if (isNilReturn(req.rop)) {
           return res.redirect(req.buildRoute('rops.nil-return'));
         }

--- a/pages/rops/procedures/list/content/index.js
+++ b/pages/rops/procedures/list/content/index.js
@@ -148,4 +148,6 @@ const condensedFields = merge({}, baseContent.fields, {
   }
 });
 
-module.exports = merge({}, baseContent, { condensedFields });
+const content = { noDataWarning: '*No procedures added yet*' };
+
+module.exports = merge({}, baseContent, { condensedFields }, content);

--- a/pages/rops/procedures/list/index.js
+++ b/pages/rops/procedures/list/index.js
@@ -1,5 +1,5 @@
 const { page } = require('@asl/service/ui');
-const { pickBy, some } = require('lodash');
+const { pickBy, pick, some } = require('lodash');
 const { datatable } = require('../../../common/routers');
 const getSchema = require('./schema');
 
@@ -28,12 +28,18 @@ module.exports = () => {
       next();
     },
     locals: (req, res, next) => {
-      // remove empty columns
-      res.locals.datatable.schema = pickBy(req.datatable.schema, (field, key) => {
-        return some(req.datatable.data.rows, row => {
-          return row[key] !== null;
+      if (req.datatable.data.rows.length > 0) {
+        // remove empty columns whem we have data
+        res.locals.datatable.schema = pickBy(req.datatable.schema, (field, key) => {
+          return some(req.datatable.data.rows, row => {
+            return row[key] !== null;
+          });
         });
-      });
+      } else {
+        // show a limited set of columns when the table is empty
+        res.locals.datatable.schema = pick(req.datatable.schema, ['rowNum', 'species', 'purposes', 'severity', 'severityNum']);
+      }
+
       req.datatable.data.rows = req.datatable.data.rows.map((row, idx) => ({ rowNum: idx + 1, ...row }));
       next();
     }

--- a/pages/rops/procedures/list/views/index.jsx
+++ b/pages/rops/procedures/list/views/index.jsx
@@ -86,7 +86,7 @@ export default function Procedures() {
         editable && (
           <Fragment>
             <p><Snippet>procedures.content</Snippet></p>
-            <ProceduresDownloadLink className="float-right" />
+            { hasProcedures && <ProceduresDownloadLink className="float-right" /> }
             <Link
               className="govuk-button"
               page="rops.procedures.create"
@@ -95,15 +95,9 @@ export default function Procedures() {
           </Fragment>
         )
       }
-      {
-        hasProcedures
-          ? (
-            <OverflowWrapper>
-              <Datatable formatters={formatters(rop)} Actions={editable && Actions} />
-            </OverflowWrapper>
-          )
-          : <p><em>No procedures added</em></p>
-      }
+      <OverflowWrapper>
+        <Datatable formatters={formatters(rop)} Actions={editable && Actions} noDataWarning={<Snippet>noDataWarning</Snippet>} />
+      </OverflowWrapper>
       <Submission />
     </div>
   );

--- a/pages/rops/submit/views/index.jsx
+++ b/pages/rops/submit/views/index.jsx
@@ -10,7 +10,7 @@ export default function Submit() {
         title={<Snippet>title</Snippet>}
         subtitle={project.title}
       />
-      <p><Snippet>declaration</Snippet></p>
+      <Snippet>declaration</Snippet>
     </FormLayout>
   );
 }

--- a/pages/task/read/content/rop.js
+++ b/pages/task/read/content/rop.js
@@ -1,7 +1,7 @@
 module.exports = {
   'sticky-nav': {
     'licence-holder': 'PPL holder',
-    'latest-return': 'Latest return'
+    'latest-return': 'Return of procedures'
   },
   'view-return': {
     content: 'View the latest return submitted on {{date}}',


### PR DESCRIPTION
Issue 2: ...a heading that says 'Latest return', please can this be changed to 'Return of procedures' 

Issue 3: ...a green banner pops up saying 'Return updated' ... Please remove.

Issue 4: ...content that says 'Add procedures completed in 2021' - please can we add a full stop 

Issue 5: ...a heading that says 'Submit this project's completed return of procedures' - please can we add a full stop

Issue 6: ...show empty procedures table

Issue 7: ...rops reporting add "Home" breadcrumb
