### PR TITLE
Remove grid column wrapper from procedures delete button

### DIFF
--- a/pages/rops/procedures/create/views/index.jsx
+++ b/pages/rops/procedures/create/views/index.jsx
@@ -97,13 +97,7 @@ export default function Create() {
           </form>
 
           {
-            deletable && (
-              <div className="govuk-grid-row">
-                <div className="govuk-grid-column-two-thirds">
-                  <DeleteButton />
-                </div>
-              </div>
-            )
+            deletable && <DeleteButton />
           }
         </div>
         <Sidebar>


### PR DESCRIPTION
It's already inside a 2/3rds column, so putting it inside another one was pushing it too far left.