### PR TITLE
Fix check for regulatory legislation step display

### DIFF
--- a/pages/rops/update/config.js
+++ b/pages/rops/update/config.js
@@ -98,7 +98,7 @@ module.exports = {
         'routine-monoclonal',
         'routine-other'
       ];
-      return hasPurpose('regulatory')(req) && without(regulatorySubpurposes, nopes).length;
+      return hasPurpose('regulatory')(req) && without(regulatorySubpurposes, ...nopes).length;
     }
   },
   'translational-subpurposes': {


### PR DESCRIPTION
This should display for only routine production sub-purposes, but the lodash function `without` was being called with an incorrect argument structure. Pass the omission list as spread arguments as expected by `without` to fix the skip step logic.