### PR TITLE
Remove "consultation required" text from PPL tasks with AA

### DIFF
--- a/pages/task/read/content/project.js
+++ b/pages/task/read/content/project.js
@@ -56,8 +56,7 @@ module.exports = {
     new: 'New establishment'
   },
   'additional-establishments': {
-    title: 'Additional establishments',
-    content: 'Consultation required with inspectors for'
+    title: 'Additional establishments'
   },
   declarations: {
     'pel-holder': {

--- a/pages/task/read/views/components/establishment-links.jsx
+++ b/pages/task/read/views/components/establishment-links.jsx
@@ -22,21 +22,16 @@ function EstablishmentLink({ establishment, showLink }) {
 
 export default function EstablishmentLinks({ establishments, showLink }) {
   return (
-    <span>
+    <ul>
       {
         sortBy(establishments, 'name').map((establishment, index) => {
-          const isLastItem = index === establishments.length - 1;
-          const showComma = index > 0 && !isLastItem;
-          const showAnd = isLastItem && establishments.length > 1;
           return (
-            <Fragment key={index}>
-              { showComma && <span>, </span> }
-              { showAnd && <span> and </span> }
+            <li key={index}>
               <EstablishmentLink key={index} establishment={establishment} showLink={showLink} />
-            </Fragment>
+            </li>
           );
         })
       }
-    </span>
+    </ul>
   );
 }

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -169,11 +169,7 @@ export default function Project({ task }) {
               !!additionalEstablishments.length && (
                 <Fragment>
                   <h3><Snippet>additional-establishments.title</Snippet></h3>
-                  <p>
-                    <Snippet>additional-establishments.content</Snippet>
-                    {' '}
-                    <EstablishmentLinks establishments={additionalEstablishments} showLink={isAsru} />
-                  </p>
+                  <EstablishmentLinks establishments={additionalEstablishments} showLink={isAsru} />
                 </Fragment>
               )
             }


### PR DESCRIPTION
This is no longer appropriate since inspectors don't have specific establishments. Revert to a bulleted list with no accompanying preamble.