### PR TITLE
Add reveal and playback of multi-input when toxicity-other-lethal selected

### DIFF
--- a/pages/rops/procedures/list/content/index.js
+++ b/pages/rops/procedures/list/content/index.js
@@ -94,7 +94,7 @@ const condensedFields = merge({}, baseContent.fields, {
       'other-efficacy': 'Other efficacy/tolerance testing:',
       'toxicity-ld50': 'Acute/sub-acute toxicity: LD50, LC50',
       'toxicity-non-lethal': 'Acute/sub-acute toxicity: Non lethal method',
-      'toxicity-other-lethal': 'Acute/sub-acute toxicity: Other lethal method:',
+      'other-toxicity-lethal': 'Acute/sub-acute toxicity: Other lethal method:',
       'toxicity-skin': 'Toxicity & skin irritation',
       'toxicity-skin-sensation': 'Toxicity & skin sensation',
       'toxicity-eye-irritation': 'Toxicity & eye irritation',

--- a/pages/rops/procedures/list/formatters/index.jsx
+++ b/pages/rops/procedures/list/formatters/index.jsx
@@ -27,7 +27,8 @@ export function getOtherValue(field, rop) {
     'qc-other': 'regulatorySubpurposesQcOther',
     'other-efficacy': 'regulatorySubpurposesOtherEfficacy',
     'other-toxicity': 'regulatorySubpurposesOtherToxicity',
-    'other-toxicity-ecotoxicity': 'regulatorySubpurposesOtherToxicityEcotoxicity'
+    'other-toxicity-ecotoxicity': 'regulatorySubpurposesOtherToxicityEcotoxicity',
+    'other-toxicity-lethal': 'regulatorySubpurposesOtherToxicityLethal'
   };
   return get(rop, otherFields[field]);
 }
@@ -82,6 +83,7 @@ const formatters = rop => {
           ...(rop.regulatorySubpurposesQcOther || []),
           ...(rop.regulatorySubpurposesOtherEfficacy || []),
           ...(rop.regulatorySubpurposesOtherToxicityEcotoxicity || []),
+          ...(rop.regulatorySubpurposesOtherToxicityLethal || []),
           ...(rop.regulatorySubpurposesOtherToxicity || []),
           ...(rop.translationalSubpurposesOther || [])
         ];

--- a/pages/rops/procedures/schema/index.js
+++ b/pages/rops/procedures/schema/index.js
@@ -215,6 +215,12 @@ function getPurposes(req) {
                   reveal: getOtherField('subpurposeOther', 'regulatorySubpurposesOtherToxicity', legislationFields)
                 };
               }
+              if (rs === 'other-toxicity-lethal') {
+                return {
+                  value: rs,
+                  reveal: getOtherField('subpurposeOther', 'regulatorySubpurposesOtherToxicityLethal', legislationFields)
+                };
+              }
               return {
                 value: rs,
                 reveal: legislationFields

--- a/pages/rops/update/content/index.js
+++ b/pages/rops/update/content/index.js
@@ -343,7 +343,7 @@ They do not include:
         'routine-monoclonal': 'Routine production: Monoclonal antibodies and polyclonal antisera',
         'routine-other': 'Routine production: Other',
         'toxicity-ld50': 'Toxicity and acute and sub-acute: LD50, LC50',
-        'toxicity-other-lethal': 'Toxicity and acute and sub-acute: Other lethal methods',
+        'other-toxicity-lethal': 'Toxicity and acute and sub-acute: Other lethal methods',
         'toxicity-non-lethal': 'Toxicity and acute and sub-acute: Non lethal methods',
         'toxicity-skin': 'Toxicity and skin irritation/corrosion',
         'other-efficacy': 'Other efficacy and tolerance testing',
@@ -386,6 +386,9 @@ They do not include:
     },
     regulatorySubpurposesOtherToxicityEcotoxicity: {
       label: 'Specify other toxicity and ecotoxicity'
+    },
+    regulatorySubpurposesOtherToxicityLethal: {
+      label: 'Specify other lethal methods'
     },
     regulatoryLegislation: {
       label: 'Which of the following types of legislation applies?',

--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -388,7 +388,12 @@ module.exports = req => {
           }
         },
         'toxicity-ld50',
-        'toxicity-other-lethal',
+        {
+          value: 'other-toxicity-lethal',
+          reveal: {
+            regulatorySubpurposesOtherToxicityLethal: getOtherField('regulatorySubpurposes')
+          }
+        },
         'toxicity-non-lethal',
         'toxicity-skin',
         'toxicity-skin-sensation',

--- a/pages/rops/update/views/components/confirm.jsx
+++ b/pages/rops/update/views/components/confirm.jsx
@@ -252,6 +252,9 @@ export default function Confirm() {
                                 {
                                   sub === 'other-toxicity-ecotoxicity' && <Inset><List items={rop.regulatorySubpurposesOtherToxicityEcotoxicity} /></Inset>
                                 }
+                                {
+                                  sub === 'other-toxicity-lethal' && <Inset><List items={rop.regulatorySubpurposesOtherToxicityLethal} /></Inset>
+                                }
                               </li>
                             ))
                           }


### PR DESCRIPTION
~Needs https://github.com/UKHomeOffice/asl-schema/pull/525 merging and then bumping in `public-api` and `resolver`~

We don't currently have any ROPs on prod using `toxicity-other-lethal` so I've renamed it to `other-toxicity-lethal` for consistency with the other "other" fields.

