### PR TITLE
updatedAt column header now correctly renders "Completed" when filtering completed tasks

### DIFF
--- a/pages/task/list/views/table.jsx
+++ b/pages/task/list/views/table.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import { Datatable } from '@asl/components';
-import formatters from '../formatters';
+import taskFormatters from '../formatters';
 
-export default function () {
-  return <Datatable formatters={formatters} className="tasklist" />;
+export default function ({ formatters = {} }) {
+  return <Datatable formatters={merge({}, taskFormatters, formatters)} className="tasklist" />;
 }

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -64,10 +64,12 @@ function TaskTabs({ tabs, selected, hasTasks }) {
 
 export default function Tasklist() {
   const { workflowConnectionError, isAsruUser, progressOptions = [] } = useSelector(state => state.static);
-  const { filters, schema, pagination } = useSelector(state => state.datatable);
+  const { filters, pagination } = useSelector(state => state.datatable);
   const progress = get(filters, 'active.progress[0]') || progressOptions[0];
   const hasTasks = pagination.totalCount > 0;
-  schema.updatedAt.label = (progress === 'completed') ? 'Completed' : undefined;
+
+  // modify the updatedAt column label when looking at completed tasks
+  const formatters = (progress === 'completed') ? { updatedAt: { label: 'Completed' } } : {};
 
   if (workflowConnectionError) {
     return (
@@ -93,7 +95,7 @@ export default function Tasklist() {
             <div className="table-heading">
               <FilterSummary resultType="tasks" />
             </div>
-            <Table />
+            <Table formatters={formatters} />
           </Fragment>
 
           : <Fragment>

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -64,9 +64,10 @@ function TaskTabs({ tabs, selected, hasTasks }) {
 
 export default function Tasklist() {
   const { workflowConnectionError, isAsruUser, progressOptions = [] } = useSelector(state => state.static);
-  const taskCount = useSelector(state => state.datatable.pagination.totalCount);
-  const progress = useSelector(state => state.static.progress) || progressOptions[0];
-  const hasTasks = taskCount > 0;
+  const { filters, schema, pagination } = useSelector(state => state.datatable);
+  const progress = get(filters, 'active.progress[0]') || progressOptions[0];
+  const hasTasks = pagination.totalCount > 0;
+  schema.updatedAt.label = (progress === 'completed') ? 'Completed' : undefined;
 
   if (workflowConnectionError) {
     return (


### PR DESCRIPTION
The `updatedAt` column now shows the correct label when the status is filtered to completed tasks.

This also fixes an issue with "My tasks" status not rendering as selected by default.