### PR TITLE
fix the links for previous PPL versions in the activity log

### DIFF
--- a/pages/task/read/routers/read.js
+++ b/pages/task/read/routers/read.js
@@ -42,6 +42,24 @@ module.exports = () => {
             req.version = data;
             req.project = data.project;
           })
+          .then(() => {
+            if (req.project.transferEstablishmentId && req.project.transferProjectId) {
+              const params = {
+                id: req.project.transferProjectId,
+                establishmentId: req.project.transferEstablishmentId,
+                licenceHolderId: req.project.licenceHolderId
+              };
+              return req.user.can('project.read.single', params)
+                .then(can => {
+                  if (can) {
+                    return req.api(`/establishment/${req.project.transferEstablishmentId}/project/${req.project.transferProjectId}`)
+                      .then(({ json: { data } }) => {
+                        res.locals.static.transferredProject = data;
+                      });
+                  }
+                });
+            }
+          })
           .then(() => next())
           .catch(next);
       }

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -139,7 +139,10 @@ function ExtraProjectMeta({ item, task }) {
     return null;
   }
 
-  const versionId = get(item, 'event.data.data.version');
+  let establishmentId = get(item, 'event.data.modelData.establishmentId');
+  let projectId = get(item, 'event.data.modelData.id');
+  let versionId = get(item, 'event.data.data.version');
+
   const status = get(item, 'event.status');
   const isEndorsed = get(item, 'event.data.meta.authority', '').toLowerCase() === 'yes';
   const isAwerbed = get(item, 'event.data.meta.awerb', '').toLowerCase() === 'yes';
@@ -150,14 +153,24 @@ function ExtraProjectMeta({ item, task }) {
   }
 
   if (status === 'resolved') {
+    const transferredProject = useSelector(state => state.static.transferredProject);
+
+    if (transferredProject) {
+      // transferredProject is only set if the user has permission to view it
+      // otherwise we default to the version at the outgoing establishment
+      establishmentId = transferredProject.establishmentId;
+      projectId = transferredProject.id;
+      versionId = transferredProject.granted.id;
+    }
+
     return (
       <div className="version-links">
         <p>
           <Link
             page="projectVersion"
             versionId={versionId}
-            establishmentId={task.data.establishmentId}
-            projectId={task.data.id}
+            establishmentId={establishmentId}
+            projectId={projectId}
             label={<Snippet date={format(item.createdAt, dateFormat.long)}>view.granted</Snippet>}
           />
         </p>
@@ -165,8 +178,8 @@ function ExtraProjectMeta({ item, task }) {
           <Link
             page="projectVersion.nts"
             versionId={versionId}
-            establishmentId={task.data.establishmentId}
-            projectId={task.data.id}
+            establishmentId={establishmentId}
+            projectId={projectId}
             label={<Snippet date={format(item.createdAt, dateFormat.long)}>view.nts</Snippet>}
           />
         </p>
@@ -182,8 +195,8 @@ function ExtraProjectMeta({ item, task }) {
             <Link
               page="projectVersion"
               versionId={versionId}
-              establishmentId={task.data.establishmentId}
-              projectId={task.data.id}
+              establishmentId={establishmentId}
+              projectId={projectId}
               label={<Snippet date={format(item.createdAt, dateFormat.long)}>view.version</Snippet>}
             />
           </p>


### PR DESCRIPTION
The previous links were using the establishment id from the task, which changes when the transfer task is handed over to the receiving establishment, which breaks the links (the existing project & version is not at the new establishment).

This PR changes the log to use the establishment from the model data in the activity event itself, which should always be the correct establishment.

Once a transfer is granted, some users will be able to view the new project / version at the receiving establishment, and for those users (receiving admins, applicant, ASRU) we link to that version. For users that can see the task but not the new version (e.g. outgoing admins) we link them to the final version at their establishment with the "transferred out" banner.