### PR TITLE
Fix normalisation of previous training course question

### DIFF
--- a/pages/project/update-licence-holder/routers/update.js
+++ b/pages/project/update-licence-holder/routers/update.js
@@ -43,9 +43,16 @@ module.exports = () => {
         .catch(next);
     },
     process(req, res, next) {
-      if (!isUndefined(req.form.values['experience-projects'])) {
-        req.form.values['experience-projects'] = req.form.values['experience-projects'] === 'true';
-      }
+      // map boolean radio button options to actual booleans
+      const fields = [
+        'experience-projects',
+        'training-has-delivered'
+      ];
+      fields.forEach(key => {
+        if (!isUndefined(req.form.values[key])) {
+          req.form.values[key] = req.form.values[key] === 'true';
+        }
+      });
       next();
     },
     locals(req, res, next) {

--- a/pages/project/update-licence-holder/views/index.jsx
+++ b/pages/project/update-licence-holder/views/index.jsx
@@ -36,7 +36,7 @@ const FormBody = ({ fields, model, formFields, submit, project }) => {
       onFieldChange={(key, value) => setValues({ ...values, [key]: value })}
     />
     {
-      Object.keys(values).filter(key => !['licenceHolderId', 'experience-projects', 'comments'].includes(key)).map(key => (
+      Object.keys(values).filter(key => !['licenceHolderId', 'experience-projects', 'training-has-delivered', 'comments'].includes(key)).map(key => (
         <input key={key} type="hidden" name={key} value={typeof values[key] === 'string' ? values[key] : JSON.stringify(values[key])} />
       ))
     }


### PR DESCRIPTION
This field wasn't being correctly mapped to a boolean when it was submitted, in the same way as the equivalent question for non-training PPLs was.

Add it to the ignore list for having an extra hidden field (used for RTE inputs) and map `'true'` to `true` in the `process` middleware.