### PR TITLE
Reorder options for GA and new genetic line questions

### DIFF
--- a/pages/rops/update/schema/index.js
+++ b/pages/rops/update/schema/index.js
@@ -304,8 +304,8 @@ module.exports = req => {
         'required'
       ],
       options: [
-        true,
-        false
+        false,
+        true
       ]
     },
     purposes: {
@@ -510,8 +510,8 @@ module.exports = req => {
         'required'
       ],
       options: [
-        true,
-        false
+        false,
+        true
       ]
     },
     productTestingTypes: {


### PR DESCRIPTION
The "default" option should come first, as per the rest of the questions.