### PR TITLE
Include revocations in available task filter options

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -38,6 +38,7 @@ module.exports = {
       options: {
         applications: 'Applications',
         amendments: 'Amendments',
+        revocations: 'Revocations',
         transfers: 'Transfers',
         continuations: 'Project continuations',
         hasDeadline: 'Deadline started',

--- a/pages/task/list/views/tasklist.jsx
+++ b/pages/task/list/views/tasklist.jsx
@@ -42,7 +42,7 @@ function TaskFilters({ hasTasks, progressOptions }) {
             label={<Snippet>filters.pplType.label</Snippet>}
             prop="pplType"
             formatter={filter => <Snippet>{`filters.pplType.options.${filter}`}</Snippet>}
-            append={['applications', 'amendments', 'transfers', 'continuations', 'hasDeadline', 'ra']}
+            append={['applications', 'amendments', 'revocations', 'transfers', 'continuations', 'hasDeadline', 'ra']}
           />
       }
     </div>


### PR DESCRIPTION
As well as applications, amendments and transfers we also want to include revocations.