### PR TITLE
Don't wrap csv values with commas

### DIFF
--- a/pages/common/routers/datatable.js
+++ b/pages/common/routers/datatable.js
@@ -155,7 +155,7 @@ module.exports = ({
       header: true,
       cast: {
         string: (value) => {
-          if (value && /[0-9]+/.test(value) && !value.includes('"')) {
+          if (value && /[0-9]+/.test(value) && !value.includes('"') && !value.includes(',')) {
             return { value: `="${value}"`, quote: false };
           } else {
             return value;


### PR DESCRIPTION
If there is a comma in the value then it already gets wrapped in double quotes, so wrapping it again in `="..."`causes it to break in new and exciting ways.