### PR TITLE
Make PPL number playback in PIL-E summary a link

### DIFF
--- a/pages/pil/unscoped/courses/formatters/index.jsx
+++ b/pages/pil/unscoped/courses/formatters/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import format from 'date-fns/format';
+import { Link } from '@asl/components';
 import { dateFormat } from '../../../../../constants';
 
 const formatDate = date => format(date, dateFormat.long);
@@ -16,7 +17,12 @@ export default {
   },
   projectId: {
     format: (id, values) => {
-      return values.project && values.project.licenceNumber;
+      return values.project && <Link
+        page="project.read"
+        projectId={id}
+        establishmentId={values.project.establishmentId}
+        label={values.project.licenceNumber}
+      />;
     }
   },
   species: {


### PR DESCRIPTION
Where we show the details of a PIL-E then make the licence number a link to the PPL page so that it can be reviewed if needed. Specific need for this is in task pages, but it has value elsewhere that this component is used.