### PR TITLE
Show task list countdown components for continuations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "10.7.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.7.0.tgz",
-      "integrity": "sha1-fBzEamvFPiy7xItn0q1PoPhUkZk=",
+      "version": "10.8.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.8.1.tgz",
+      "integrity": "sha1-ZOGhfkyMItptsBqcOcIwDhtW1d4=",
       "requires": {
         "@asl/constants": "^1.0.0",
         "@asl/dictionary": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^10.7.0",
+    "@asl/components": "^10.8.1",
     "@asl/constants": "^1.0.0",
     "@asl/dictionary": "^1.1.5",
     "@asl/projects": "^10.0.9",

--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -9,10 +9,20 @@ module.exports = {
   title: 'Task list',
   pageTitle: 'Task list',
   countdown: {
-    singular: '1 {{unit}} left',
-    plural: '{{diff}} {{unit}}s left',
-    expired: 'Deadline passed',
-    expiresToday: 'Deadline today'
+    deadline: {
+      singular: 'Statutory deadline: 1 {{unit}}',
+      plural: 'Statutory deadline: {{diff}} {{unit}}s',
+      expired: 'Statutory deadline: passed',
+      expiresToday: 'Statutory deadline: today'
+    },
+    continuation: {
+      singular: 'Project continuation: 1 {{unit}}',
+      plural: 'Project continuation: {{diff}} {{unit}}s',
+      expired: 'Project continuation: passed',
+      expiresToday: 'Project continuation: today',
+      unknown: 'Includes project continuation',
+      closed: 'Project continuation: done'
+    }
   },
   tabs: {
     outstanding: 'Outstanding',
@@ -52,6 +62,5 @@ module.exports = {
     completed: 'You have no completed tasks',
     myTasks: 'There are no tasks assigned to you'
   },
-  'tasklist-unavailable': 'Task list unavailable',
-  continuation: 'Includes project continuation'
+  'tasklist-unavailable': 'Task list unavailable'
 };


### PR DESCRIPTION
* Adds a countdown for PPL applications with a continuation where there is a date provided
* Falls back to the old `Includes project continuation` if it's an old task with unstructured data, or the user has not entered a date
* Is based on the earliest continuation date if there are multiple
* Show a "done" message once the PPL application is resolved