### PR TITLE
Allow the tasklist formatters to be used with task search results

### DIFF
--- a/pages/task/list/formatters/index.jsx
+++ b/pages/task/list/formatters/index.jsx
@@ -96,7 +96,7 @@ export default {
   type: {
     format: (type, task) => {
       const id = get(task, 'id');
-      const status = get(task, 'data.modelData.status') || get(task, 'status');
+      const status = get(task, 'data.modelData.status') || get(task, 'modelStatus');
       let licence = get(task, 'data.model') || get(task, 'model');
 
       if (licence === 'trainingPil') {


### PR DESCRIPTION
Task search results are a slimmer / flattened object when compared with tasks returned from the workflow API - update the formatters to be able to cope with the new shape.