### PR TITLE
Always show links to task on success pages

### DIFF
--- a/pages/success/content/index.js
+++ b/pages/success/content/index.js
@@ -100,6 +100,10 @@ module.exports = {
       body: `This request has been approved.`,
       internal: 'The relevant people have been emailed.',
       external: ''
+    },
+    taskLink: {
+      before: 'You can ',
+      linkText: 'view the history of this request.'
     }
   },
   'rejected': {
@@ -109,6 +113,10 @@ module.exports = {
     whatNext: {
       body: `This request has been rejected.`,
       internal: 'The relevant people have been emailed.'
+    },
+    taskLink: {
+      before: 'You can ',
+      linkText: 'view the history of this request.'
     }
   },
   'revoked': {
@@ -118,6 +126,10 @@ module.exports = {
     whatNext: {
       body: `This licence has been revoked.`,
       internal: 'The relevant people have been emailed.'
+    },
+    taskLink: {
+      before: 'You can ',
+      linkText: 'view the history of this request.'
     }
   }
 };

--- a/pages/success/index.js
+++ b/pages/success/index.js
@@ -132,9 +132,7 @@ module.exports = () => {
     merge(res.locals.static.content, { success });
     res.locals.static.taskId = req.taskId;
     res.locals.static.taskLabel = getTaskLabel(req.task);
-    res.locals.static.successType = successType;
     res.locals.static.establishment = req.establishment || get(req.task, 'data.establishment');
-    res.locals.static.taskIsOpen = get(req.task, 'isOpen');
     res.locals.static.isAsruUser = req.user.profile.asruUser;
     res.locals.static.additionalInfo = getAdditionalInfo(req);
 

--- a/pages/success/views/index.jsx
+++ b/pages/success/views/index.jsx
@@ -7,13 +7,9 @@ const Index = ({ onwardLink }) => {
     establishment,
     taskLabel,
     taskId,
-    taskIsOpen,
     isAsruUser,
-    additionalInfo,
-    successType
+    additionalInfo
   } = useSelector(state => state.static);
-
-  const showTask = taskIsOpen || successType === 'rop-submitted';
 
   return (
     <div className="govuk-grid-row success">
@@ -34,12 +30,7 @@ const Index = ({ onwardLink }) => {
           <p><Snippet optional>success.whatNext.body</Snippet></p>
           <p><Snippet optional>{`success.whatNext.${isAsruUser ? 'internal' : 'external'}`}</Snippet></p>
 
-          {
-            showTask &&
-              <p>
-                <Snippet>success.taskLink.before</Snippet> <Link page="task.read" label={<Snippet>success.taskLink.linkText</Snippet>} taskId={taskId} />
-              </p>
-          }
+          <p><Snippet>success.taskLink.before</Snippet> <Link page="task.read" label={<Snippet>success.taskLink.linkText</Snippet>} taskId={taskId} /></p>
         </div>
 
         {


### PR DESCRIPTION
Previously the success pages for resolved/closed tasks provided no onward navigation to view the resolved thing. Add a link back to the task from the success page when closing tasks so that the person can then easily view the licence.