### PR TITLE
Pass static content to project state initialisation

### DIFF
--- a/pages/project-version/read/js/index.js
+++ b/pages/project-version/read/js/index.js
@@ -42,5 +42,8 @@ start({
     isActionable: state.static.isActionable,
     taskLink: state.static.taskLink
   },
-  static: { urls: state.static.urls }
+  static: {
+    urls: state.static.urls,
+    content: state.static.content
+  }
 });

--- a/pages/project-version/update/js/index.js
+++ b/pages/project-version/update/js/index.js
@@ -45,5 +45,8 @@ start({
     training: state.static.training,
     licenceHolder: state.model.licenceHolder
   },
-  static: { urls: state.static.urls }
+  static: {
+    urls: state.static.urls,
+    content: state.static.content
+  }
 });

--- a/pages/retrospective-assessment/update/js/index.js
+++ b/pages/retrospective-assessment/update/js/index.js
@@ -34,5 +34,8 @@ start({
     schemaVersion: 'RA',
     licenceHolder: state.static.project.licenceHolder
   },
-  static: { urls: state.static.urls }
+  static: {
+    urls: state.static.urls,
+    content: state.static.content
+  }
 });


### PR DESCRIPTION
This is required to do key-value mapping of training module names in the training sections