### PR TITLE
Ensure species list in ROPs is unique

### DIFF
--- a/pages/rops/helpers.js
+++ b/pages/rops/helpers.js
@@ -1,12 +1,14 @@
-const { get, intersection, flatten } = require('lodash');
+const { get, intersection, flatten, uniq } = require('lodash');
 
 function getSpecies(req) {
   const projectSpecies = (get(req, 'project.granted.data.species') || []).filter(s => !s.includes('other'));
   const ropSpecies = flatten(Object.values(get(req, 'rop.species') || {})).filter(s => !s.match(/^other-/));
 
-  return req.rop.otherSpecies
+  const species = req.rop.otherSpecies
     ? projectSpecies.concat(ropSpecies) // user answered yes to "other animal types used" so merge project and rop species
     : (ropSpecies.length > 0 ? ropSpecies : projectSpecies); // otherwise use rops species or fall back to proj species
+
+  return uniq(species);
 }
 
 function hasNhps(req, option) {


### PR DESCRIPTION
In order to not break when changing species after entering procedures, preselected species in the species selector now send their value to the server. This includes species that are preselected because they are listed on the PPL.

This means that the same species can end up included in the list of species loaded from the PPL as well as in the list of manually added species.

To prevent these appearing twice, call `uniq` on the set of returned species.