### PR TITLE
Remove playback component in ROPs for legacy PPLs

### DIFF
--- a/pages/rops/update/views/components/endandered.jsx
+++ b/pages/rops/update/views/components/endandered.jsx
@@ -4,6 +4,12 @@ import { Snippet } from '@asl/components';
 
 export default function Endangered() {
   const endangered = useSelector(state => state.static.hasEndangeredSpecies);
+
+  const isLegacy = useSelector(state => state.model.project.schemaVersion === 0);
+  if (isLegacy) {
+    return null;
+  }
+
   return (
     <Fragment>
       <h3><Snippet>playback</Snippet></h3>

--- a/pages/rops/update/views/components/ga.jsx
+++ b/pages/rops/update/views/components/ga.jsx
@@ -4,6 +4,12 @@ import { Snippet } from '@asl/components';
 
 export default function GA() {
   const { hasGeneticallyAltered } = useSelector(state => state.static);
+
+  const isLegacy = useSelector(state => state.model.project.schemaVersion === 0);
+  if (isLegacy) {
+    return null;
+  }
+
   return (
     <Fragment>
       <h3><Snippet>playback</Snippet></h3>

--- a/pages/rops/update/views/components/reuse.jsx
+++ b/pages/rops/update/views/components/reuse.jsx
@@ -4,6 +4,12 @@ import { Snippet } from '@asl/components';
 
 export default function Reuse() {
   const reuse = useSelector(state => state.static.hasReUse);
+
+  const isLegacy = useSelector(state => state.model.project.schemaVersion === 0);
+  if (isLegacy) {
+    return null;
+  }
+
   return (
     <Fragment>
       <h3><Snippet>playback</Snippet></h3>

--- a/pages/rops/update/views/components/species.jsx
+++ b/pages/rops/update/views/components/species.jsx
@@ -4,10 +4,10 @@ import { Snippet } from '@asl/components';
 import ReviewField from '@asl/projects/client/components/review-field';
 
 export default function Species() {
-  const { schemaVersion } = useSelector(state => state.model.project);
+  const isLegacy = useSelector(state => state.model.project.schemaVersion === 0);
   const { hasOtherSpecies, projectSpecies } = useSelector(state => state.static);
 
-  if (schemaVersion === 0 || hasOtherSpecies) {
+  if (isLegacy || hasOtherSpecies) {
     return null;
   }
 


### PR DESCRIPTION
For questions relating to GA animals, re-use and endangered animals it is not possible to reliably determine the authorisation or otherwise on the project for legacy licences so these are showing up incorrectly as not authorised in some cases.

Hide all playback of values for legacy PPLs to avoid this.