### PR TITLE
Hide comments in PPL preview view

### DIFF
--- a/pages/project-version/read/index.js
+++ b/pages/project-version/read/index.js
@@ -40,7 +40,7 @@ module.exports = settings => {
     res.locals.static.establishment = req.project.establishment;
     res.locals.static.isActionable = get(task, 'data.data.version') === req.versionId;
     res.locals.static.user = req.user.profile;
-    res.locals.static.showComments = showComments;
+    res.locals.static.showComments = !req.isPreview && showComments;
     res.locals.static.commentable = !req.isPreview && showComments && req.user.profile.asruUser && res.locals.static.isCommentable;
 
     const taskId = task ? task.id : null;


### PR DESCRIPTION
Inspectors were reporting concern that they could see their comments embedded in the licence when previewing it.