### PR TITLE
Send response immediately in ROPs confirm update router

### DIFF
--- a/pages/rops/update/confirm/index.js
+++ b/pages/rops/update/confirm/index.js
@@ -16,5 +16,7 @@ module.exports = () => {
     next();
   });
 
+  app.get('/', (req, res) => res.sendResponse());
+
   return app;
 };


### PR DESCRIPTION
This was falling through to a later router which was overwriting `res.locals.model` and resulting in an error loading the header component on this page.

Terminate response in this router to prevent fall-through.