### PR TITLE
Filter AA to only active on profile pages

### DIFF
--- a/pages/profile/read/views/profile.jsx
+++ b/pages/profile/read/views/profile.jsx
@@ -9,9 +9,10 @@ import LeaveEstablishment from './leave-establishment';
 import { dateFormat } from '../../../../constants';
 
 function ProjectDetails({ project, establishment }) {
+  const additionalEstablishments = (project.additionalEstablishments || []).filter(aa => aa.status === 'active');
   const isAdditionalAvailability = project.establishmentId !== establishment.id;
-  const hasAdditionalAvailability = (project.additionalEstablishments || []).length > 0;
-  const aaEstablishmentNames = (project.additionalEstablishments || []).map(e => e.name).sort().join(', ');
+  const hasAdditionalAvailability = additionalEstablishments.length > 0;
+  const aaEstablishmentNames = additionalEstablishments.map(e => e.name).sort().join(', ');
   const isDraft = project.status === 'inactive';
   const showInfo = !isDraft || project.isLegacyStub || hasAdditionalAvailability || isAdditionalAvailability;
 


### PR DESCRIPTION
A project with an open amendment to _add_ an additional establishment was showing on the user's profile as having additional availability already even though the amendment had not been granted.