### PR TITLE
Add fixed width to notes columns in procedures list

### DIFF
--- a/pages/common/assets/sass/style.scss
+++ b/pages/common/assets/sass/style.scss
@@ -127,6 +127,16 @@ form.procedures {
       font-size: 16px;
       white-space: nowrap;
       padding: 5px 10px 5px 0;
+      vertical-align: top;
+
+      .markdown {
+        white-space: normal;
+        width: 500px;
+
+        p, ul, ol {
+          margin-top: 0;
+        }
+      }
     }
   }
 }

--- a/pages/rops/procedures/list/formatters/index.jsx
+++ b/pages/rops/procedures/list/formatters/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import flatten from 'lodash/flatten';
 import get from 'lodash/get';
 import { projectSpecies } from '@asl/constants';
-import { Snippet } from '@asl/components';
+import { Snippet, Markdown } from '@asl/components';
 
 const allSpecies = flatten(Object.values(projectSpecies));
 
@@ -43,6 +43,13 @@ const getRadioOption = field => v => {
   }
 
   return <Snippet fallback={`condensedFields.${field}.options.${v}`}>{`condensedFields.${field}.options.${v}.label`}</Snippet>;
+};
+
+const formatNote = value => {
+  if (!value) {
+    return null;
+  }
+  return <div className="markdown"><Markdown>{ value }</Markdown></div>;
 };
 
 const formatters = rop => {
@@ -134,6 +141,12 @@ const formatters = rop => {
     },
     severity: {
       format: getRadioOption('severity')
+    },
+    severityHoNote: {
+      format: formatNote
+    },
+    severityPersonalNote: {
+      format: formatNote
     }
   };
 };


### PR DESCRIPTION
Setting a width (or min/max-width) on the table cell itself doesn;t work because once the table is wider than it's container it will always attempt to reduce the width of all columns as far as possible.

This means we need to set a fixed width on a child element of the column in order to restrict how far the table can reduce the width of the column once we allow the text to break onto new lines.