### PR TITLE
Add warning on PPL amendment submission

### DIFF
--- a/pages/project-version/update/endorse/content/index.js
+++ b/pages/project-version/update/endorse/content/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   title: 'Send {{type}}',
   warning: {
-    canEndorse: `This application needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
-    cantEndorse: `The primary establishment will need to endorse your application, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+    canEndorse: `This {{type}} needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
+    cantEndorse: `The primary establishment will need to endorse your {{type}}, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
   },
   declaration: {
     title: 'Declaration',

--- a/pages/project-version/update/endorse/content/index.js
+++ b/pages/project-version/update/endorse/content/index.js
@@ -1,8 +1,14 @@
 module.exports = {
   title: 'Send {{type}}',
   warning: {
-    canEndorse: `This {{type}} needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
-    cantEndorse: `The primary establishment will need to endorse your {{type}}, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+    application: {
+      canEndorse: `This application needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
+      cantEndorse: `The primary establishment will need to endorse your application, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+    },
+    amendment: {
+      canEndorse: `This amendment needs to be endorsed by the establishment licence holder, and, if relevant, reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
+      cantEndorse: `The primary establishment will need to endorse your amendment, and, if relevant, confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+    }
   },
   declaration: {
     title: 'Declaration',

--- a/pages/project-version/update/endorse/views/index.jsx
+++ b/pages/project-version/update/endorse/views/index.jsx
@@ -22,7 +22,7 @@ export default function Submit() {
         subtitle={project.title || 'Untitled project'}
       />
       <Warning>
-        <Snippet type={type}>{`warning.${canEndorse ? 'canEndorse' : 'cantEndorse'}`}</Snippet>
+        <Snippet>{`warning.${type}.${canEndorse ? 'canEndorse' : 'cantEndorse'}`}</Snippet>
       </Warning>
     </FormLayout>
   );

--- a/pages/project-version/update/endorse/views/index.jsx
+++ b/pages/project-version/update/endorse/views/index.jsx
@@ -6,6 +6,7 @@ import { Warning } from '@ukhomeoffice/react-components';
 export default function Submit() {
   const { canEndorse, project } = useSelector(state => state.static);
   const isApplication = project.type === 'application';
+  const type = isApplication ? 'application' : 'amendment';
 
   const declaration = (
     <Fragment>
@@ -20,11 +21,9 @@ export default function Submit() {
         title={<Snippet>title</Snippet>}
         subtitle={project.title || 'Untitled project'}
       />
-      {isApplication && (
-        <Warning>
-          <Snippet>{`warning.${canEndorse ? 'canEndorse' : 'cantEndorse'}`}</Snippet>
-        </Warning>
-      )}
+      <Warning>
+        <Snippet type={type}>{`warning.${canEndorse ? 'canEndorse' : 'cantEndorse'}`}</Snippet>
+      </Warning>
     </FormLayout>
   );
 }


### PR DESCRIPTION
There was a warning on application submission about needing endorsement from admin users on submission of applications. Now amendments need the same endorsement so also include the same content there but with ~application~ amendment.