### PR TITLE
Allow previous year to remain "active" in project landing page ROPs section

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -1,11 +1,7 @@
 function getRopsYears(start) {
-  let stop = (new Date()).getFullYear() + 1;
-
-  if (process.env.INCLUDE_NEXT_YEAR_ROPS) {
-    stop = stop + 1;
-  }
-
-  const years = Array.from({ length: stop - start }, (num, i) => start + i);
+  let end = (new Date()).getFullYear();
+  // array length should be 1 when start and end are the same
+  const years = Array.from({ length: 1 + end - start }, (num, i) => start + i);
 
   return years.reverse();
 }

--- a/pages/project/read/views/components/rops.jsx
+++ b/pages/project/read/views/components/rops.jsx
@@ -117,7 +117,10 @@ export function Rops({ project = {}, ropsYears = [], url, today = new Date() }) 
     ];
   }
 
-  const activeYears = years.filter(year => year >= thisYear);
+  const activeYears = years.filter(year => {
+    // the previous year should be "active" for the first part of the year
+    return year >= thisYear || (year === thisYear - 1 && today.getMonth() < 6);
+  });
 
   const rops = project.rops;
 


### PR DESCRIPTION
For the early part of the year the previous year's ROPs are likely the most pertinent for a user, so allow the previous year to be considered "active" on the project landing page so that expanded content is available.