### PR TITLE
Allow PPL transfers to display comments

### DIFF
--- a/pages/project-version/index.js
+++ b/pages/project-version/index.js
@@ -11,7 +11,7 @@ module.exports = settings => {
 
   app.use(bodyParser.json({ limit: settings.bodySizeLimit }));
 
-  app.use(getVersion(), getComments(), (req, res, next) => {
+  app.use(getVersion(), getComments(['grant', 'transfer']), (req, res, next) => {
     res.locals.static.establishment = req.project.establishment;
     res.locals.static.project = {
       ...req.project,

--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -1,4 +1,4 @@
-const { get, remove, isEqual, uniq, mapValues, sortBy, pickBy, isEmpty } = require('lodash');
+const { get, remove, isEqual, uniq, mapValues, sortBy, pickBy, isEmpty, castArray } = require('lodash');
 const isUUID = require('uuid-validate');
 const extractComments = require('../lib/extract-comments');
 const { mapSpecies, mapPermissiblePurpose, mapAnimalQuantities } = require('@asl/projects/client/helpers');
@@ -25,7 +25,7 @@ const getVersion = () => (req, res, next) => {
     .catch(next);
 };
 
-const getComments = (action = 'grant') => (req, res, next) => {
+const getComments = (actions = ['grant', 'transfer']) => (req, res, next) => {
   if (!req.project || !req.project.openTasks || !req.project.openTasks.length) {
     return next();
   }
@@ -33,7 +33,7 @@ const getComments = (action = 'grant') => (req, res, next) => {
     // the application task for AA projects won't be visible so don't try to load it
     return next();
   }
-  const task = get(req.project, 'openTasks', []).find(task => get(task, 'data.action') === action);
+  const task = get(req.project, 'openTasks', []).find(task => castArray(actions).includes(get(task, 'data.action')));
   if (!task) {
     return next();
   }


### PR DESCRIPTION
Comments are not being shown on PPL transfers because the code tries to find a task with a `grant` action to load comments from, and the task for a transfer has an action of `transfer`.

Allow comments to be loaded from transfers as well as applications and amendments.