### PR TITLE
Make default year for establishment ROPs list dynamic

### DIFF
--- a/pages/establishment/rops/index.js
+++ b/pages/establishment/rops/index.js
@@ -11,7 +11,11 @@ module.exports = settings => {
   });
 
   app.get('/', (req, res, next) => {
-    res.redirect(req.buildRoute('establishment.rops.overview', { year: 2021 }));
+    const now = new Date();
+    res.redirect(req.buildRoute('establishment.rops.overview', {
+      // default to previous year in Jan-Jun
+      year: now.getMonth() < 6 ? now.getFullYear() - 1 : now.getFullYear()
+    }));
   });
 
   return app;


### PR DESCRIPTION
Between January and June the default year will be the previous year's ROPs, but from July onwards default to the current year.