### PR TITLE
Get project type from correct location on store

### DIFF
--- a/pages/project-version/update/endorse/views/index.jsx
+++ b/pages/project-version/update/endorse/views/index.jsx
@@ -4,7 +4,8 @@ import { Snippet, Header, FormLayout } from '@asl/components';
 import { Warning } from '@ukhomeoffice/react-components';
 
 export default function Submit() {
-  const { canEndorse, project } = useSelector(state => state.static);
+  const { canEndorse } = useSelector(state => state.static);
+  const project = useSelector(state => state.model);
   const isApplication = project.type === 'application';
   const type = isApplication ? 'application' : 'amendment';
 


### PR DESCRIPTION
The type property of the project under `static` was always undefined, and so the content always showed as an amendment.

Load the value from the correct location so applications display correctly.