### PR TITLE
Improvements to task deadlines in status header

### DIFF
--- a/pages/task/read/content/project.js
+++ b/pages/task/read/content/project.js
@@ -18,11 +18,11 @@ module.exports = {
     view: 'View retrospective assessment'
   },
   continuation: {
-    title: 'This is a project continuation',
+    title: 'Project continuation',
     licence: 'From the licence',
-    expiry: 'Expiry',
-    rte: 'Original input',
-    label: 'Please state the licence number and expiry date of all these licences.'
+    rte: 'Original continuation input',
+    from: 'From project licence {{licenceNumber}}',
+    expiry: 'expiring on {{expiry}}'
   },
   fields: {
     status: {
@@ -83,8 +83,15 @@ module.exports = {
     button: 'Reopen task'
   },
   deadline: {
-    title: 'Deadline for decision: ',
+    decision: 'Deadline for decision: {{date}}',
+    processBy: 'Process by: {{date}}',
+    internal: 'Internal deadline',
+    statutory: {
+      standard: 'Statutory deadline for decision',
+      extended: 'Extended deadline for decision'
+    },
     extension: {
+      action: 'Extend deadline',
       from: 'Deadline extended from: ',
       to: 'Deadline extended to: '
     },

--- a/pages/task/read/views/components/deadline.jsx
+++ b/pages/task/read/views/components/deadline.jsx
@@ -1,50 +1,136 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { Fragment } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
 import get from 'lodash/get';
+import differenceInCalendarDays from 'date-fns/difference_in_calendar_days';
+import { ReviewFields } from '@asl/projects/client/components/review-fields';
 import { Link, Snippet, Details } from '@asl/components';
 import { dateFormat } from '../../../../../constants';
 import { formatDate } from '../../../../../lib/utils';
 
-export default function Deadline({ task }) {
-  const isInspector = useSelector(state => state.static.isInspector);
-  const deadline = get(task, 'data.deadline');
-  const isExtended = get(deadline, 'isExtended', false);
-  const deadlineDate = get(deadline, isExtended ? 'extended' : 'standard');
+function DaysSince({ days }) {
+  if (days === 0) {
+    return (
+      <span className="deadline-passed">
+        <br />
+        <Snippet>deadline.today</Snippet>
+      </span>
+    );
+  }
 
-  if (!deadlineDate) {
+  if (days > 0) {
+    return (
+      <span className="deadline-passed">
+        <br />
+        <Snippet days={days}>{`deadline.passed.${days > 1 ? 'plural' : 'singular'}`}</Snippet>
+      </span>
+    );
+  }
+
+  return null; // still in future
+}
+
+export default function Deadline({ task }) {
+  const { isAsru, isInspector, version } = useSelector(state => state.static, shallowEqual);
+
+  const statutoryDeadline = get(task, 'data.deadline');
+  const isExtended = get(statutoryDeadline, 'isExtended', false);
+  const statutoryDeadlineDate = get(statutoryDeadline, isExtended ? 'extended' : 'standard');
+  const internalDeadline = get(task, 'data.internalDeadline');
+  const internalDeadlineDate = get(internalDeadline, isExtended ? 'extended' : 'standard');
+  const activeDeadlineDate = get(task, 'activeDeadline');
+
+  const continuation = get(task, 'data.continuation');
+  const continuationRTE = get(version, 'data.expiring-yes');
+
+  if (!activeDeadlineDate) {
     return null;
   }
 
   return (
     <div className="deadline">
-      <h3><Snippet>deadline.title</Snippet> {formatDate(deadlineDate, dateFormat.long)}</h3>
-
-      {
-        deadline.daysSince >= 0 &&
-          <p className="deadline-passed gutter">
-            {
-              deadline.daysSince === 0 && <Snippet>deadline.today</Snippet>
-            }
-            {
-              deadline.daysSince > 0 &&
-                <Snippet days={deadline.daysSince}>{`deadline.passed.${deadline.daysSince > 1 ? 'plural' : 'singular'}`}</Snippet>
-            }
-          </p>
+      { isAsru &&
+        <h2><Snippet date={formatDate(activeDeadlineDate, dateFormat.long)}>deadline.processBy</Snippet></h2>
       }
 
-      { isInspector && deadline && deadline.isExtendable &&
-        <div className="gutter">
-          <Details summary="Extend deadline">
-            <p><Snippet>deadline.hint</Snippet></p>
-            <Link
-              page="task.read.extend"
-              taskId={task.id}
-              label={<Snippet>deadline.extend.button</Snippet>}
-              className="govuk-button button-secondary"
-            />
-          </Details>
-        </div>
-      }
+      <dl className="inline-wide">
+
+        { isAsru && internalDeadline &&
+          <Fragment>
+            <dt><Snippet>deadline.internal</Snippet></dt>
+            <dd>
+              {formatDate(internalDeadlineDate, dateFormat.long)}
+              <DaysSince days={differenceInCalendarDays(new Date(), internalDeadlineDate)} />
+            </dd>
+          </Fragment>
+        }
+
+        { statutoryDeadline &&
+          <Fragment>
+            <dt><Snippet>{`deadline.statutory.${statutoryDeadline.isExtended ? 'extended' : 'standard'}`}</Snippet></dt>
+            <dd>
+              {formatDate(statutoryDeadlineDate, dateFormat.long)}
+              <DaysSince days={statutoryDeadline.daysSince} />
+
+              {
+                statutoryDeadline.isExtendable && isInspector &&
+                  <Details summary="Extend deadline">
+                    <p><Snippet>deadline.hint</Snippet></p>
+                    <Link
+                      page="task.read.extend"
+                      taskId={task.id}
+                      label={<Snippet>deadline.extend.button</Snippet>}
+                      className="govuk-button button-secondary"
+                    />
+                  </Details>
+              }
+            </dd>
+          </Fragment>
+        }
+
+        {
+          continuation &&
+            <Fragment>
+              <dt><Snippet>continuation.title</Snippet></dt>
+              <dd>
+                {
+                  continuation.map((item, index) => (
+                    <p key={index}>
+                      {
+                        item['licence-number']
+                          ? <Fragment>
+                            <Snippet licenceNumber={item['licence-number']}>continuation.from</Snippet>
+                            { item['expiry-date'] &&
+                              <Fragment>
+                                <br />
+                                <Snippet expiry={formatDate(item['expiry-date'], dateFormat.medium)}>continuation.expiry</Snippet>
+                              </Fragment>
+                            }
+                          </Fragment>
+                          : <em>No answer provided</em>
+                      }
+                    </p>
+                  ))
+                }
+              </dd>
+            </Fragment>
+        }
+        {
+          continuationRTE && (
+            <Fragment>
+              <dt><Snippet>continuation.rte</Snippet></dt>
+              <dd>
+                <ReviewFields
+                  fields={[{ name: 'expiring-yes', type: 'texteditor' }]}
+                  values={{ 'expiring-yes': continuationRTE }}
+                  readonly={true}
+                  noComments
+                />
+              </dd>
+            </Fragment>
+          )
+        }
+      </dl>
+
     </div>
   );
 }

--- a/pages/task/read/views/models/project.jsx
+++ b/pages/task/read/views/models/project.jsx
@@ -52,8 +52,6 @@ export default function Project({ task }) {
   const { project, establishment, version, ra, values, isAsru, allowedActions, url } = useSelector(state => state.static, shallowEqual);
   const [disabled, setDisabled] = useState(false);
 
-  const continuation = task.data.continuation;
-  const continuationRTE = get(version, 'data.expiring-yes');
   // always use licence holder from project for applications
   const licenceHolder = project.status === 'inactive'
     ? project.licenceHolder
@@ -195,55 +193,6 @@ export default function Project({ task }) {
             }
 
           </p>
-        </StickyNavAnchor>
-      )
-    ),
-
-    (
-      continuation && (
-        <StickyNavAnchor id="continuation" key="continuation">
-          <h2><Snippet>continuation.title</Snippet></h2>
-          {
-            continuation.map((item, index) => (
-              <dl className="inline continuation" key={index}>
-                <dt><Snippet>continuation.licence</Snippet></dt>
-                <dd>
-                  {
-                    item['licence-number']
-                      ? item['licence-number']
-                      : <em>No answer provided</em>
-                  }
-                </dd>
-                <dt><Snippet>continuation.expiry</Snippet></dt>
-                <dd>
-                  {
-                    item['expiry-date']
-                      ? format(item['expiry-date'], dateFormat.long)
-                      : <em>No answer provided</em>
-                  }
-                </dd>
-              </dl>
-            ))
-          }
-          {
-            continuationRTE && (
-              <div className="gutter">
-                <h3><Snippet>continuation.rte</Snippet></h3>
-                <label className="govuk-hint"><Snippet>continuation.label</Snippet></label>
-                <ReviewFields
-                  fields={[{
-                    name: 'expiring-yes',
-                    type: 'texteditor'
-                  }]}
-                  values={{
-                    'expiring-yes': continuationRTE
-                  }}
-                  readonly={true}
-                  noComments
-                />
-              </div>
-            )
-          }
         </StickyNavAnchor>
       )
     ),


### PR DESCRIPTION
Needs:
 - https://github.com/UKHomeOffice/asl-workflow/pull/435

Any relevant deadlines are now displayed in the task status section, including project continuations if present.

![int-past-stat-past](https://user-images.githubusercontent.com/1880478/155349119-9e1e5a13-0ff1-4efc-8690-9f2d4bc77e87.png)

