### PR TITLE
Reset session values when adding an exemption

### DIFF
--- a/pages/training/type/index.js
+++ b/pages/training/type/index.js
@@ -5,7 +5,14 @@ const schema = require('./schema');
 module.exports = () => {
   const app = page({ root: __dirname });
 
-  app.use(form({ schema }));
+  app.use(form({
+    schema,
+    saveValues: (req, res, next) => {
+      // remove possible certificate values from session when adding an exemption and vice versa
+      req.session.form[req.model.id].values = req.form.values;
+      next();
+    }
+  }));
 
   app.post('/', (req, res, next) => {
     const { isExemption } = req.form.values;


### PR DESCRIPTION
If a user starts adding a certificate, then cancels and adds an exemption then some fields are persisted on the certificate, which causes a schema validation error when submitting the exemption.

Reset the session values when submitting the form to choose between an exemption and certificate to avoid incorrect values being persisted.