### PR TITLE
Go back to short labels for the task list

### DIFF
--- a/pages/task/list/content/index.js
+++ b/pages/task/list/content/index.js
@@ -5,7 +5,26 @@ const tasks = require('../../content/tasks');
 module.exports = {
   status,
   fields,
-  tasks,
+  tasks: {
+    ...tasks,
+    pil: {
+      grant: 'PIL application',
+      update: 'PIL amendment',
+      revoke: 'PIL revocation',
+      transfer: 'PIL transfer',
+      review: 'PIL review'
+    },
+    trainingPil: {
+      grant: 'Training PIL application',
+      revoke: 'Training PIL revocation'
+    },
+    project: {
+      grant: 'PPL application',
+      transfer: 'PPL transfer',
+      update: 'PPL amendment',
+      revoke: 'PPL revocation'
+    }
+  },
   title: 'Task list',
   pageTitle: 'Task list',
   tabs: {


### PR DESCRIPTION
Updating the task headings on the task view page had the knock on effect of also changing them in the task lists as the label was shared.

This returns the task list back to the shorter "PIL/PPL application" labels.