### PR TITLE
Improvements to ROPs tasks

### DIFF
--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -240,6 +240,10 @@ module.exports = {
     },
     log: 'Rejected by'
   },
+  reopened: {
+    state: 'Reopened',
+    log: 'Reopened by'
+  },
   recovered: {
     state: 'Reopened',
     log: 'Reopened by'

--- a/pages/task/content/tasks.js
+++ b/pages/task/content/tasks.js
@@ -4,8 +4,8 @@ module.exports = {
     delete: 'Remove named person{{#type}} ({{type}}){{/type}}'
   },
   rop: {
-    submit: 'Return of procedures',
-    unsubmit: 'Return of procedures'
+    submit: 'Return of procedures{{#year}} ({{year}}){{/year}}',
+    unsubmit: 'Return of procedures{{#year}} ({{year}}){{/year}}'
   },
   place: {
     create: 'New approved area',

--- a/pages/task/content/tasks.js
+++ b/pages/task/content/tasks.js
@@ -4,7 +4,8 @@ module.exports = {
     delete: 'Remove named person{{#type}} ({{type}}){{/type}}'
   },
   rop: {
-    submit: 'Return of procedures'
+    submit: 'Return of procedures',
+    unsubmit: 'Return of procedures'
   },
   place: {
     create: 'New approved area',

--- a/pages/task/list/formatters/index.jsx
+++ b/pages/task/list/formatters/index.jsx
@@ -48,8 +48,8 @@ export default {
   },
   status: {
     format: (status, task) => {
-      const isRop = (get(task, 'data.model') || get(task, 'model')) === 'rop';
-      const className = classnames({ badge: true, complete: good.includes(status) || isRop, rejected: bad.includes(status) });
+      const isRopSubmission = (get(task, 'data.model') || get(task, 'model')) === 'rop' && get(task, 'data.action') === 'submit';
+      const className = classnames({ badge: true, complete: good.includes(status) || isRopSubmission, rejected: bad.includes(status) });
 
       return (
         <span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span>
@@ -89,6 +89,10 @@ export default {
       }
 
       switch (licence) {
+        case 'rop':
+          labelParams.year = get(task, 'data.modelData.year');
+          // don't break, allow ROPs to also use the subject as the context label
+          // eslint-ignore-next-line no-fallthrough
         case 'project':
         case 'pil':
         case 'role':
@@ -104,9 +108,6 @@ export default {
           if (placeName) {
             contextLabel = placeName;
           }
-          break;
-        case 'rop':
-          contextLabel = get(task, 'data.modelData.year');
           break;
       }
 

--- a/pages/task/list/formatters/index.jsx
+++ b/pages/task/list/formatters/index.jsx
@@ -49,11 +49,7 @@ export default {
   status: {
     format: (status, task) => {
       const isRop = (get(task, 'data.model') || get(task, 'model')) === 'rop';
-      const className = classnames({ badge: true, complete: good.includes(status || isRop), rejected: bad.includes(status) });
-
-      if (isRop) {
-        status = 'resubmitted';
-      }
+      const className = classnames({ badge: true, complete: good.includes(status) || isRop, rejected: bad.includes(status) });
 
       return (
         <span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span>
@@ -108,6 +104,9 @@ export default {
           if (placeName) {
             contextLabel = placeName;
           }
+          break;
+        case 'rop':
+          contextLabel = get(task, 'data.modelData.year');
           break;
       }
 

--- a/pages/task/list/router.js
+++ b/pages/task/list/router.js
@@ -2,6 +2,7 @@ const { get, set, omit } = require('lodash');
 const { NotFoundError } = require('@asl/service/errors');
 const defaultSchema = require('./schema');
 const datatable = require('../../common/routers/datatable');
+const ropStatus = require('../middleware/rop-status');
 
 const getProgressOptions = profile => {
   const options = ['outstanding', 'inProgress', 'completed'];
@@ -40,6 +41,7 @@ module.exports = ({
     req.datatable.apiPath = [req.datatable.apiPath, { query: { ...req.query, progress } }];
     next();
   },
+  getValues: ropStatus(),
   errorHandler: (err, req, res, next) => {
     req.log('error', { ...err, message: err.message, stack: err.stack });
     res.locals.static.workflowConnectionError = true;

--- a/pages/task/middleware/rop-status.js
+++ b/pages/task/middleware/rop-status.js
@@ -1,0 +1,21 @@
+const { get } = require('lodash');
+
+module.exports = () => (req, res, next) => {
+  const fixStatus = task => {
+    if (task.data.model === 'rop') {
+      if (task.data.action === 'submit') {
+        task.status = 'resubmitted';
+      }
+      if (task.data.action === 'unsubmit') {
+        task.status = 'reopened';
+      }
+    }
+  };
+  if (req.task) {
+    fixStatus(req.task);
+  }
+  if (get(req, 'datatable.data.rows')) {
+    req.datatable.data.rows.forEach(fixStatus);
+  }
+  next();
+};

--- a/pages/task/read/routers/read.js
+++ b/pages/task/read/routers/read.js
@@ -10,6 +10,7 @@ const { cleanModel } = require('../../../../lib/utils');
 const getContent = require('../content');
 const { getEstablishment } = require('../../../common/helpers');
 const updateData = require('../middleware/update-data');
+const ropStatus = require('../../middleware/rop-status');
 
 const endorsingOwnPil = (task, profile) => {
   const isNtco = !!profile.roles.find(r => r.type === 'ntco' && r.establishmentId === task.data.establishmentId);
@@ -18,6 +19,8 @@ const endorsingOwnPil = (task, profile) => {
 
 module.exports = () => {
   const app = Router({ mergeParams: true });
+
+  app.use(ropStatus());
 
   // get relevant versionId if task is for a project.
   app.use((req, res, next) => {

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -26,7 +26,7 @@ function Action({ task, action, activity, changedBy }) {
     return <p><strong><Snippet>status.autodiscarded.log</Snippet></strong></p>;
   }
   if (task.data.model === 'rop') {
-    action = 'resubmitted';
+    action = task.status;
   }
 
   const establishmentId = get(activity, 'event.data.establishmentId');

--- a/pages/task/read/views/components/task-details.jsx
+++ b/pages/task/read/views/components/task-details.jsx
@@ -89,6 +89,17 @@ function EstablishmentsList({ establishments }) {
   );
 }
 
+function ROPYear({ task }) {
+  if (task.data.model !== 'rop') {
+    return null;
+  }
+  const year = useSelector(state => state.static.values.year);
+  return <Fragment>
+    <dt>Return for year</dt>
+    <dd>{ year }</dd>
+  </Fragment>;
+}
+
 function ProjectDetails({ task }) {
   const project = useSelector(state => state.static.project) || useSelector(state => state.static.values.project);
   const version = useSelector(state => state.static.version);
@@ -106,6 +117,7 @@ function ProjectDetails({ task }) {
       <ProfileLink profile={profile} establishment={establishment} type={profileType} />
       <LicenceNumber>{project.licenceNumber}</LicenceNumber>
       <EstablishmentLink establishment={establishment} />
+      { task.data.model === 'rop' && <ROPYear task={task} /> }
     </dl>
   );
 }

--- a/pages/task/read/views/components/task-status.jsx
+++ b/pages/task/read/views/components/task-status.jsx
@@ -3,7 +3,6 @@ import get from 'lodash/get';
 import classnames from 'classnames';
 import { Snippet } from '@asl/components';
 import Deadline from './deadline';
-import { isDeadlineExtension } from '../../../../../lib/utils';
 
 const getStatusBadge = (status, model) => {
   const good = ['resolved'];
@@ -14,21 +13,7 @@ const getStatusBadge = (status, model) => {
 
 export default function TaskStatus({ task }) {
   const model = get(task, 'data.model');
-  const latestActivity = task.activityLog.filter(a => a.eventName !== 'assign')[0];
-  let { action, status } = latestActivity;
-
-  if (model === 'project') {
-    const isExtension = isDeadlineExtension(latestActivity);
-
-    if (action === 'update' && isExtension) {
-      status = 'with-inspectorate';
-      action = 'with-inspectorate';
-    }
-  }
-
-  if (model === 'rop') {
-    status = 'resubmitted';
-  }
+  const status = task.status;
 
   let snippetContent = `status.${status}.currentlyWith`;
 

--- a/pages/task/read/views/models/rop.jsx
+++ b/pages/task/read/views/models/rop.jsx
@@ -10,7 +10,7 @@ export default function ROP({ task }) {
   return (
     <StickyNavAnchor id="latest-return" key="latest-return">
       <h2><Snippet>sticky-nav.latest-return</Snippet></h2>
-      <p><Snippet date={format(task.createdAt, dateFormat.long)}>view-return.content</Snippet></p>
+      { task.status !== 'reopened' && <p><Snippet date={format(task.createdAt, dateFormat.long)}>view-return.content</Snippet></p> }
       <p className="gutter">
         <Link
           className="govuk-button"


### PR DESCRIPTION
We want to make ROP reopening tasks visible in task histories for projects.

* Add playback of the ROPs year in task lists and task details
* Add new content for `reopened` status
* Remove logic which remaps statuses of ROPs ~because this is now done in workflow decorator~ - UPDATE: map the statuses in a server middleware here instead.
* Hide message about ROP submission date on `reopened` tasks