### PR TITLE
Remove version data from form model in PPL endorse form

### DIFF
--- a/pages/project-version/update/endorse/routers/endorse.js
+++ b/pages/project-version/update/endorse/routers/endorse.js
@@ -68,6 +68,7 @@ module.exports = (settings = {}) => {
           type = 'transfer request';
         }
         req.model.type = type;
+        req.model.data = null;
         // if application has previously been approved then this is a resubmission and we can show the inspector ready question
         const hasAuthority = get(existingTask, 'data.meta.authority');
         const isAmendment = req.model.type !== 'application';


### PR DESCRIPTION
The `getValues` function in the form router does a recursive clone of `req.model` with possibly harmful characters removed from all strings. This results in a ~2x increase in the memory usage when `req.model` represents a PPL version since both the sanitised and unsantised versions are stored in memory.

Since the endorsement form does not require any of the version data to be available it can be removed from `req.model` in the form setup step, and so avoid cloning large PPL data objects in memory.