### PR TITLE
Don't throw if changing licence holder on a PPL to a collaborator

### DIFF
--- a/pages/project/update-licence-holder/index.js
+++ b/pages/project/update-licence-holder/index.js
@@ -25,6 +25,17 @@ module.exports = () => {
       .then(({ json: { data } }) => {
         req.proposedLicenceHolder = data;
       })
+      .catch(err => {
+        // if profile returns 404 it is likely a collaborator
+        if (err.status === 404) {
+          const recipient = req.project.collaborators.find(collab => collab.id === licenceHolderId);
+          if (recipient) {
+            req.proposedLicenceHolder = recipient;
+            return;
+          }
+        }
+        throw err;
+      })
       .then(() => next())
       .catch(next);
   });


### PR DESCRIPTION
When changing the licence holder on a PPL we do an API call to load the profile of the recipient, but in the case of a basic user moving their PPL to a collaborator this API call can fail because they don't have visibility of the profile.

In that case look in the list of collaborators for the intended recipient and use the details from there.