### PR TITLE
Update endorsement content if submitting on behalf of another user

### DIFF
--- a/pages/project-version/update/endorse/content/index.js
+++ b/pages/project-version/update/endorse/content/index.js
@@ -2,19 +2,24 @@ module.exports = {
   title: 'Send {{type}}',
   warning: {
     application: {
-      canEndorse: `This application needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
-      cantEndorse: `The primary establishment will need to endorse your application, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+      isEndorsement: `This application needs to be endorsed by the establishment licence holder, and reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
+      needsEndorsement: `The primary establishment will need to endorse your application, and confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
     },
     amendment: {
-      canEndorse: `This amendment needs to be endorsed by the establishment licence holder, and, if relevant, reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
-      cantEndorse: `The primary establishment will need to endorse your amendment, and, if relevant, confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
+      isEndorsement: `This amendment needs to be endorsed by the establishment licence holder, and, if relevant, reviewed by the Animal Welfare and Ethical Review Body (AWERB) at the primary and any additional establishments, before a licence can be granted.`,
+      needsEndorsement: `The primary establishment will need to endorse your amendment, and, if relevant, confirm it’s been reviewed by the relevant Animal Welfare and Ethical Review Bodies (AWERBs), before a licence can be granted.`
     }
   },
   declaration: {
     title: 'Declaration',
-    content: `By endorsing this {{type}}, I agree that:
+    content: `By endorsing this {{type}} on behalf of {{establishment.name}}, I agree that:
       * {{licenceHolder}}'s training record is accurate and up to date.
-      * The non-technical summary uses everyday language and contains no information that could identify people, places or intellectual property.`
+      * The non-technical summary uses everyday language and contains no information that could identify people, places or intellectual property.
+      {{#onBehalfOf}}
+
+      By submitting this {{type}} on behalf of {{licenceHolder}}, I agree that:
+      * they are aware I am making this submission and I have their permission to do so.
+      {{/onBehalfOf}}`
   },
   fields: {
     authority: {

--- a/pages/project-version/update/endorse/views/index.jsx
+++ b/pages/project-version/update/endorse/views/index.jsx
@@ -5,7 +5,7 @@ import { Snippet, Header, FormLayout } from '@asl/components';
 import { Warning } from '@ukhomeoffice/react-components';
 
 export default function Submit() {
-  const { canEndorse } = useSelector(state => state.static);
+  const { isEndorsement } = useSelector(state => state.static);
   const type = useSelector(state => state.model.type);
   const title = useSelector(state => state.model.title || get(state, 'model.project.title') || 'Untitled project');
   const isApplication = type === 'application';
@@ -19,13 +19,13 @@ export default function Submit() {
   );
 
   return (
-    <FormLayout declaration={canEndorse && declaration}>
+    <FormLayout declaration={isEndorsement && declaration}>
       <Header
         title={<Snippet>title</Snippet>}
         subtitle={title}
       />
       <Warning>
-        <Snippet>{`warning.${taskType}.${canEndorse ? 'canEndorse' : 'cantEndorse'}`}</Snippet>
+        <Snippet>{`warning.${taskType}.${isEndorsement ? 'isEndorsement' : 'needsEndorsement'}`}</Snippet>
       </Warning>
     </FormLayout>
   );


### PR DESCRIPTION
When an admin is submitting a PPL application or amendment on behalf of another user then add a second section to the declaration to say that they have the permission of the PPL holder to make the submission.

Also fixes a bug where the endorsing admin at the receiving establishment of a transfer was not shown endorsement declarations.