### PR TITLE
Prevent the discard button from being activated more than once

### DIFF
--- a/pages/pil/dashboard/views/index.jsx
+++ b/pages/pil/dashboard/views/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import { connect } from 'react-redux';
 import {
   Snippet,
@@ -16,14 +16,6 @@ import SectionDetails from './section-details';
 import ProceduresDiff from '../../procedures/views/diff';
 import SpeciesDiff from '../../species/views/diff';
 
-function confirmDelete(e) {
-  e.preventDefault();
-
-  if (window.confirm('Are you sure you want to delete this draft PIL application?')) {
-    e.target.submit();
-  }
-}
-
 const Index = ({
   pil,
   establishment,
@@ -36,6 +28,17 @@ const Index = ({
 
   const beforeProcs = pil.procedures.map(p => (p.key ? p : { key: p }));
   const afterProcs = model.procedures.map(p => (p.key ? p : { key: p }));
+
+  const [disableDiscard, setDisableDiscard] = useState(false);
+
+  function confirmDelete(e) {
+    e.preventDefault();
+
+    if (window.confirm('Are you sure you want to delete this draft PIL application?')) {
+      setDisableDiscard(true);
+      e.target.submit();
+    }
+  }
 
   const sections = [
     {
@@ -115,7 +118,7 @@ const Index = ({
             onSubmit={confirmDelete}
             className="control-panel"
           >
-            <button className="link"><span>Discard draft application</span></button>
+            <button className="link" disabled={disableDiscard}><span>Discard draft application</span></button>
           </form>
         )
       }


### PR DESCRIPTION
The "Discard draft application" link is actually a button that triggers a confirm dialogue which then submits a form.

If the user was quick enough, they could accept the dialogue and then click the button again - the previous submit request will have already been processed and the second attempt will fail because the PIL no longer exists to be deleted.

Prevent the discard button from being clicked again if the form has been submitted.