### PR TITLE
Default to empty data in draft RA

### DIFF
--- a/pages/project-version/nts/views/components/ra-summary.jsx
+++ b/pages/project-version/nts/views/components/ra-summary.jsx
@@ -34,7 +34,7 @@ export default function RaSummary({ project, fields, includeDraftRa = false, isP
           return (
             <Fragment key={index}>
               <h3>{field.label}</h3>
-              <Field field={field} version={ra.data} />
+              <Field field={field} version={ra.data || {}} />
             </Fragment>
           );
         })


### PR DESCRIPTION
If someone has started an RA but not entered _any_ input into any field then the `data` is null, and attempts to read properties from it throws an error.