### PR TITLE
Correctly read `draftRa` from query string

### DIFF
--- a/pages/project-version/pdf/index.jsx
+++ b/pages/project-version/pdf/index.jsx
@@ -36,7 +36,7 @@ module.exports = settings => {
         isFullApplication: isFullApplication && req.project.schemaVersion > 0,
         raCompulsory: req.version.raCompulsory,
         licenceHolder: req.version.licenceHolder,
-        includeDraftRa: !!req.query.draftRa
+        includeDraftRa: req.query.draftRa === 'true'
       },
       static: {
         content,


### PR DESCRIPTION
The value is a string, so was being set to true always, even when `draftRa=false` was passed as the query string. This resulted in the RA values being incorrectly read when `draftRa=false` was set on a non-draft RA.