### PR TITLE
Show NHPs questions if user has selected `other-nhps`

### DIFF
--- a/pages/rops/helpers.js
+++ b/pages/rops/helpers.js
@@ -21,6 +21,9 @@ function hasNhps(req, option) {
   if (option) {
     return yeps.includes(option);
   }
+  if ((get(req, 'rop.species.precoded') || []).includes('other-nhps')) {
+    return true;
+  }
   const species = getSpecies(req);
   return !!intersection(species, yeps).length;
 }


### PR DESCRIPTION
The `getSpecies` function removes any `other-*` values and replaces them with the free text, so wasn't catching `other-nhps` as being an NHP return.

If `other-nhps` is used then return true straight away.