### PR TITLE
Redirect task confirmation page if session is expired

### DIFF
--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -46,6 +46,9 @@ module.exports = () => {
   app.use(form({
     configure: (req, res, next) => {
       const chosenStatus = get(req, `session.form[${req.task.id}].values.status`);
+      if (!chosenStatus) {
+        return res.redirect(req.buildRoute('task.read'));
+      }
       res.locals.static.commentRequired = req.task.nextSteps.find(s => s.id === chosenStatus).commentRequired;
       res.locals.static.commentLabel = content.commentLabels[chosenStatus];
       req.schema = getSchema({ task: req.task, chosenStatus });


### PR DESCRIPTION
If the status of the task is no longer available on the session then building the schema fails with an error. Instead redirect back to the task page and allow the user to recommence the journey.