### PR TITLE
ASL-4040 Tasks for PIL conditions should not display a diff of the licence

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,6 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!@asl)'
   ],
-  setupTestFrameworkScriptFile: '<rootDir>/enzyme.setup.js'
+  setupTestFrameworkScriptFile: '<rootDir>/enzyme.setup.js',
+  snapshotSerializers: ['enzyme-to-json/serializer']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "diff": "^5.0.0",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
+        "enzyme-to-json": "^3.6.2",
         "express": "^4.16.3",
         "filenamify": "^4.1.0",
         "image-size": "^0.7.4",
@@ -2491,6 +2492,14 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.31",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
+      "integrity": "sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -5475,6 +5484,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/enzyme-to-json": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.6.2.tgz",
+      "integrity": "sha512-Ynm6Z6R6iwQ0g2g1YToz6DWhxVnt8Dy1ijR2zynRKxTyBGA8rCDXU3rs2Qc4OKvUvc2Qoe1bcFK6bnPs20TrTg==",
+      "dependencies": {
+        "@types/cheerio": "^0.22.22",
+        "lodash": "^4.17.21",
+        "react-is": "^16.12.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -16393,6 +16418,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cheerio": {
+      "version": "0.22.31",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
+      "integrity": "sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -18805,6 +18838,16 @@
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.6.2.tgz",
+      "integrity": "sha512-Ynm6Z6R6iwQ0g2g1YToz6DWhxVnt8Dy1ijR2zynRKxTyBGA8rCDXU3rs2Qc4OKvUvc2Qoe1bcFK6bnPs20TrTg==",
+      "requires": {
+        "@types/cheerio": "^0.22.22",
+        "lodash": "^4.17.21",
+        "react-is": "^16.12.0"
       }
     },
     "error-ex": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "diff": "^5.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
+    "enzyme-to-json": "^3.6.2",
     "express": "^4.16.3",
     "filenamify": "^4.1.0",
     "image-size": "^0.7.4",

--- a/pages/task/read/views/models/__snapshots__/pil.spec.jsx.snap
+++ b/pages/task/read/views/models/__snapshots__/pil.spec.jsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PIL /> renders only conditions when action is update-conditions 1`] = `
+<ForwardRef
+  id="conditions"
+  key="conditions"
+>
+  <h2>
+    <Connect(Snippet)>
+      sticky-nav.conditions
+    </Connect(Snippet)>
+  </h2>
+  <DiffText
+    currentLabel={
+      <UNDEFINED>
+        diff.previous
+      </UNDEFINED>
+    }
+    newValue="old-conditions"
+    oldValue="new-conditions"
+    proposedLabel={
+      <UNDEFINED>
+        diff.changed-to
+      </UNDEFINED>
+    }
+  />
+</ForwardRef>
+`;
+
+exports[`<PIL /> renders when action is update 1`] = `
+Array [
+  <ForwardRef
+    id="procedures"
+    key="procedures"
+  >
+    <h2>
+      <Connect(Snippet)>
+        sticky-nav.procedures
+      </Connect(Snippet)>
+    </h2>
+    <PilProcedures
+      task={
+        Object {
+          "data": Object {
+            "data": Object {
+              "certificates": Array [
+                Object {},
+                Object {},
+              ],
+            },
+          },
+          "isOpen": false,
+        }
+      }
+    />
+  </ForwardRef>,
+  <ForwardRef
+    id="species"
+    key="species"
+  >
+    <h2>
+      <Connect(Snippet)>
+        sticky-nav.species
+      </Connect(Snippet)>
+    </h2>
+    <SpeciesDiff
+      after={
+        Object {
+          "certificates": Array [
+            Object {},
+            Object {},
+          ],
+        }
+      }
+    />
+  </ForwardRef>,
+  <ForwardRef
+    id="training"
+    key="training"
+  >
+    <h2>
+      <Connect(Snippet)>
+        sticky-nav.training
+      </Connect(Snippet)>
+    </h2>
+    <SummaryTable
+      certificates={Array []}
+    />
+  </ForwardRef>,
+]
+`;

--- a/pages/task/read/views/models/pil.jsx
+++ b/pages/task/read/views/models/pil.jsx
@@ -28,83 +28,85 @@ function PilProcedures({ task }) {
 export default function PIL({ task, values }) {
   const isTransfer = task.type === 'transfer';
   const isReview = task.type === 'review';
+  const isUpdateConditions = task.data.action === 'update-conditions';
   const certificates = task.data.certificates || [];
   const showTraining = !isReview || certificates.length > 0;
 
   const isComplete = !task.isOpen;
-
-  let pil = task.data.action === 'update-conditions' ? values : task.data.data;
+  let pil = isUpdateConditions ? values : task.data.data;
   if (isReview) {
     pil = task.data.modelData;
   }
 
-  return [
-    (
-      isTransfer &&
-        <StickyNavAnchor id="establishment" key="establishment">
-          <h2><Snippet>{`sticky-nav.${isTransfer ? 'transfer' : 'establishment'}`}</Snippet></h2>
-          <table className="govuk-table compare">
-            <thead>
-              <tr>
-                <th><Snippet>pil.establishment.current</Snippet></th>
-                <th><Snippet>pil.establishment.proposed</Snippet></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
+  const navAnchors = [];
+
+  if (isTransfer) {
+    navAnchors.push(
+      <StickyNavAnchor id="establishment" key="establishment">
+        <h2><Snippet>{`sticky-nav.${isTransfer ? 'transfer' : 'establishment'}`}</Snippet></h2>
+        <table className="govuk-table compare">
+          <thead>
+            <tr>
+              <th><Snippet>pil.establishment.current</Snippet></th>
+              <th><Snippet>pil.establishment.proposed</Snippet></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <Link
+                  page="establishment.dashboard"
+                  establishmentId={pil.establishment.from.id}
+                  label={pil.establishment.from.name}
+                />
+              </td>
+              <td>
+                <span className="highlight">
                   <Link
                     page="establishment.dashboard"
-                    establishmentId={pil.establishment.from.id}
-                    label={pil.establishment.from.name}
+                    establishmentId={pil.establishment.to.id}
+                    label={pil.establishment.to.name}
                   />
-                </td>
-                <td>
-                  <span className="highlight">
-                    <Link
-                      page="establishment.dashboard"
-                      establishmentId={pil.establishment.to.id}
-                      label={pil.establishment.to.name}
-                    />
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </StickyNavAnchor>
-    ),
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </StickyNavAnchor>
+    );
+  }
 
-    <StickyNavAnchor id="procedures" key="procedures">
-      <h2><Snippet>sticky-nav.procedures</Snippet></h2>
-      <PilProcedures task={task} />
-    </StickyNavAnchor>,
+  if (isUpdateConditions) {
+    navAnchors.push(
+      <StickyNavAnchor id="conditions" key="conditions">
+        <h2><Snippet>sticky-nav.conditions</Snippet></h2>
+        <DiffText
+          oldValue={pil.conditions}
+          newValue={task.data.data.conditions}
+          currentLabel={isComplete && <Snippet>diff.previous</Snippet>}
+          proposedLabel={isComplete && <Snippet>diff.changed-to</Snippet>}
+        />
+      </StickyNavAnchor>
+    );
+  } else {
+    navAnchors.push([
+      <StickyNavAnchor id="procedures" key="procedures">
+        <h2><Snippet>sticky-nav.procedures</Snippet></h2>
+        <PilProcedures task={task} />
+      </StickyNavAnchor>,
 
-    <StickyNavAnchor id="species" key="species">
-      <h2><Snippet>sticky-nav.species</Snippet></h2>
-      <SpeciesDiff before={task.data.modelData} after={task.data.data} taskType={task.type} />
-    </StickyNavAnchor>,
-
-    (
+      <StickyNavAnchor id="species" key="species">
+        <h2><Snippet>sticky-nav.species</Snippet></h2>
+        <SpeciesDiff before={task.data.modelData} after={task.data.data} taskType={task.type} />
+      </StickyNavAnchor>,
       showTraining && (
         <StickyNavAnchor id="training" key="training">
           <h2><Snippet>sticky-nav.training</Snippet></h2>
           <TrainingSummary certificates={certificates} />
         </StickyNavAnchor>
       )
-    ),
+    ]);
+  }
 
-    (
-      task.data.action === 'update-conditions' && (
-        <StickyNavAnchor id="conditions" key="conditions">
-          <h2><Snippet>sticky-nav.conditions</Snippet></h2>
-          <DiffText
-            oldValue={pil.conditions}
-            newValue={task.data.data.conditions}
-            currentLabel={isComplete && <Snippet>diff.previous</Snippet>}
-            proposedLabel={isComplete && <Snippet>diff.changed-to</Snippet>}
-          />
-        </StickyNavAnchor>
-      )
-    )
-  ];
+  return navAnchors;
 }

--- a/pages/task/read/views/models/pil.spec.jsx
+++ b/pages/task/read/views/models/pil.spec.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import Pil from "./pil";
+
+describe('<PIL />', () => {
+
+  test('renders when action is update', () => {
+    const props = {
+      task: {
+        data: {
+          data: {
+            certificates: [{}, {}]
+          }
+        },
+        isOpen: false
+      }
+    };
+    const component = shallow(<Pil {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders only conditions when action is update-conditions', () => {
+    const props = {
+      task: {
+        data: {
+          action: 'update-conditions',
+          data: {
+            conditions: 'old-conditions'
+          }
+        },
+        isOpen: false
+      },
+      values: {
+        conditions: 'new-conditions'
+      }
+    };
+    const component = shallow(<Pil {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
An update conditions should now be displaying without the Procedures, Animal types and Training:
![Conditions](https://user-images.githubusercontent.com/1784700/178953014-4114afad-f4ca-4e92-9459-2672f61d3e21.png)

There doesn't seem to be many unit tests around the components in asl-pages. Have added a second commit with a snapshot test with a couple of scenarios that may be useful for catching regressions within the components.