### PR TITLE
Don't throw error on profile updates for non-PIL-holders

### DIFF
--- a/pages/task/read/views/components/task-details.jsx
+++ b/pages/task/read/views/components/task-details.jsx
@@ -152,7 +152,7 @@ function ProfileDetails({ task }) {
     <dl className="inline-wide">
       <ProfileLink profile={profile} type="global" />
       { isApplication && <Over18 profile={profile} /> }
-      { !isApplication && profile.pilLicenceNumber &&
+      { !isApplication && profile.pilLicenceNumber && profile.pil &&
         <LicenceNumber>
           <Link page="pil.read" establishmentId={profile.pil.establishmentId} profileId={profile.id} label={profile.pilLicenceNumber} />
         </LicenceNumber>


### PR DESCRIPTION
If a user has a PPL or a named role but no longer has an active PIL, then `profile.pil` will not exist and so profile update tasks throw errors.