### PR TITLE
Feature: refuse a project application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "27.20.1",
       "license": "MIT",
       "dependencies": {
-        "@asl/components": "^10.14.6",
+        "@asl/components": "^10.14.7",
         "@asl/constants": "^1.2.1",
         "@asl/dictionary": "^1.1.5",
         "@asl/projects": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
-    "@asl/components": "^10.14.6",
+    "@asl/components": "^10.14.7",
     "@asl/constants": "^1.2.1",
     "@asl/dictionary": "^1.1.5",
     "@asl/projects": "^10.7.6",

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -101,6 +101,8 @@ module.exports = {
         removeDeadline: 'Remove deadline',
         reinstateDeadline: 'Reinstate deadline',
         confirm: 'Confirm',
+        confirmRefuse: 'Confirm',
+        review: 'Review',
         success: 'Success',
         deadlinePassed: 'Deadline passed reason'
       }

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -231,6 +231,7 @@ module.exports = {
       inactive: 'Draft',
       pending: 'Draft',
       revoked: 'Revoked',
+      refused: 'Refused',
       expired: 'Expired',
       active: 'Amendment in progress',
       superseded: 'Superseded',

--- a/pages/project-version/components/project-status-banner.jsx
+++ b/pages/project-version/components/project-status-banner.jsx
@@ -8,6 +8,7 @@ import { dateFormat } from '../../../constants';
 export default function ProjectStatusBanner({ model = {}, version = {}, isPdf }) {
   const { canViewTransferredProject, additionalAvailability } = useSelector(state => state.static);
   const additionalAvailabilityRemoved = additionalAvailability && additionalAvailability.status === 'removed';
+
   if (model.status === 'transferred') {
     return (
       <LicenceStatusBanner title={<Snippet>invalidLicence.status.transferred</Snippet>} licence={model} licenceType="ppl" version={version.id} isPdf={isPdf} colour="red">
@@ -22,6 +23,18 @@ export default function ProjectStatusBanner({ model = {}, version = {}, isPdf })
       </LicenceStatusBanner>
     );
   }
+
+  if (model.refusedAt) {
+    return (
+      <LicenceStatusBanner title={<Snippet>invalidLicence.status.refused</Snippet>} licence={model} colour="red" isPdf={isPdf}>
+        <Fragment>
+          <p><strong>Refused: <span>{format(model.refusedAt, dateFormat.long)}</span></strong></p>
+          <p><Snippet>invalidLicence.summary.ppl</Snippet></p>
+        </Fragment>
+      </LicenceStatusBanner>
+    );
+  }
+
   if (model.status === 'active') {
     if (model.isLegacyStub) {
       return (
@@ -35,6 +48,7 @@ export default function ProjectStatusBanner({ model = {}, version = {}, isPdf })
     if (model.granted && model.granted.id === version.id && !additionalAvailabilityRemoved) {
       return null;
     }
+
     model.versions = model.versions || [];
 
     const grantedVersions = sortBy(model.versions.filter(v => v.status === 'granted'), 'updatedAt');
@@ -67,5 +81,5 @@ export default function ProjectStatusBanner({ model = {}, version = {}, isPdf })
     );
   }
 
-  return <LicenceStatusBanner licence={model} licenceType="ppl" version={version.id} isPdf={isPdf} colour={model.status === 'transferred' && 'red'} />;
+  return <LicenceStatusBanner licence={model} licenceType="ppl" version={version.id} isPdf={isPdf} />;
 }

--- a/pages/project-version/components/project-status-banner.jsx
+++ b/pages/project-version/components/project-status-banner.jsx
@@ -24,11 +24,11 @@ export default function ProjectStatusBanner({ model = {}, version = {}, isPdf })
     );
   }
 
-  if (model.refusedAt) {
+  if (model.refusedDate) {
     return (
       <LicenceStatusBanner title={<Snippet>invalidLicence.status.refused</Snippet>} licence={model} colour="red" isPdf={isPdf}>
         <Fragment>
-          <p><strong>Refused: <span>{format(model.refusedAt, dateFormat.long)}</span></strong></p>
+          <p><strong>Refused: <span>{format(model.refusedDate, dateFormat.long)}</span></strong></p>
           <p><Snippet>invalidLicence.summary.ppl</Snippet></p>
         </Fragment>
       </LicenceStatusBanner>

--- a/pages/project/content/index.js
+++ b/pages/project/content/index.js
@@ -74,7 +74,8 @@ module.exports = {
     transferred: 'Transferred',
     expired: 'Expired',
     revoked: 'Revoked',
-    'additional-availability-ended': 'Availability removed'
+    'additional-availability-ended': 'Availability removed',
+    refused: 'Refused'
   },
   tabs: {
     inactive: 'Drafts'

--- a/pages/project/formatters/index.jsx
+++ b/pages/project/formatters/index.jsx
@@ -7,7 +7,7 @@ import { formatDate } from '../../../lib/utils';
 import { dateFormat } from '../../../constants';
 import { projectTitle } from '../../common/formatters';
 
-const bad = ['expired', 'transferred', 'revoked', 'additional-availability-ended'];
+const bad = ['expired', 'transferred', 'revoked', 'additional-availability-ended', 'refused'];
 const good = ['active'];
 
 function EstablishmentList({ establishments }) {
@@ -75,6 +75,11 @@ const formatters = establishmentId => ({
       if (additionalAvailabilityEnded) {
         status = 'additional-availability-ended';
       }
+
+      if (model.refusedDate) {
+        status = 'refused';
+      }
+
       const className = classnames({ badge: true, complete: good.includes(status), rejected: bad.includes(status) });
       return (
         <Fragment>

--- a/pages/success/content/index.js
+++ b/pages/success/content/index.js
@@ -139,5 +139,17 @@ module.exports = {
       before: 'You can ',
       linkText: 'view the history of this request.'
     }
+  },
+  'refused': {
+    panel: {
+      title: 'Refused'
+    },
+    whatNext: {
+      body: `This application for a licence has been refused. The applicant and establishment admins have been notified.`
+    },
+    taskLink: {
+      before: 'You can ',
+      linkText: 'view the history of this request.'
+    }
   }
 };

--- a/pages/success/content/index.js
+++ b/pages/success/content/index.js
@@ -92,6 +92,14 @@ module.exports = {
       body: `This request has been referred to an inspector.`
     }
   },
+  'intention-to-refuse': {
+    panel: {
+      title: 'Sent'
+    },
+    whatNext: {
+      body: `The application has been returned and the notice of intention to refuse has been sent to the applicant and establishment.`
+    }
+  },
   'resolved': {
     panel: {
       title: 'Approved'

--- a/pages/success/index.js
+++ b/pages/success/index.js
@@ -66,6 +66,10 @@ const getSuccessType = task => {
     return 'endorsed';
   }
 
+  if (latestActivity && get(latestActivity, 'event.status') === 'intention-to-refuse') {
+    return 'intention-to-refuse';
+  }
+
   if (task.status === 'resolved' && action === 'revoke') {
     return 'revoked';
   }

--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -249,6 +249,14 @@ module.exports = {
     },
     log: 'Rejected by'
   },
+  'intention-to-refuse': {
+    state: 'Returned',
+    action: 'Notify of intention to refuse',
+    hint: {
+      application: 'The applicant will be sent a notice with 28 days to respond'
+    },
+    log: 'Refused by'
+  },
   reopened: {
     state: 'Reopened',
     log: 'Reopened by'

--- a/pages/task/content/status.js
+++ b/pages/task/content/status.js
@@ -253,7 +253,23 @@ module.exports = {
     state: 'Returned',
     action: 'Notify of intention to refuse',
     hint: {
-      application: 'The applicant will be sent a notice with 28 days to respond'
+      application: 'The applicant will be sent a notice with 28 days to respond.'
+    },
+    log: {
+      application: 'Notice of intention to refuse issued by'
+    },
+    warning: {
+      future: `The Home Office are planning to refuse this application. You have until {{respondBy}} to respond.`,
+      futureAsru: `The Home Office are planning to refuse this application. The applicant has until {{respondBy}} to respond.`,
+      passed: 'The 28 day deadline for responding to the intention to refuse notice has passed.',
+      passedAsru: 'The 28 day deadline for responding to the intention to refuse notice has passed. If the applicant has not responded you should refuse the licence.'
+    }
+  },
+  refused: {
+    state: 'Refused',
+    action: 'Refuse licence',
+    hint: {
+      application: 'The 28 day deadline for responding to the refusal notice has passed. If the applicant has not responded you should refuse the licence.'
     },
     log: 'Refused by'
   },

--- a/pages/task/list/formatters/index.jsx
+++ b/pages/task/list/formatters/index.jsx
@@ -8,7 +8,7 @@ import { dateFormat } from '../../../../constants';
 import { Snippet, Link } from '@asl/components';
 
 const good = ['resolved'];
-const bad = ['rejected', 'discarded-by-applicant'];
+const bad = ['rejected', 'withdrawn', 'discarded-by-applicant', 'refused'];
 
 const Deadline = ({ task }) => {
   const activeDeadline = task.activeDeadline;

--- a/pages/task/read/content/base.js
+++ b/pages/task/read/content/base.js
@@ -25,6 +25,7 @@ module.exports = {
     'referred-to-inspector': 'inspector referral',
     'inspector-rejected': 'refusal',
     'rejected': 'refusal',
+    'intention-to-refuse': 'refusal',
     'discarded-by-asru': 'discarding'
   },
   'sticky-nav': {

--- a/pages/task/read/content/confirm.js
+++ b/pages/task/read/content/confirm.js
@@ -2,6 +2,7 @@ const { merge, pick } = require('lodash');
 const baseContent = require('./base');
 const tasks = require('../../content/tasks');
 const versionContent = require('../../../project-version/update/endorse/content');
+const refusalNotice = require('./refusal-notice');
 
 module.exports = merge({}, baseContent, {
   tasks,
@@ -34,5 +35,9 @@ module.exports = merge({}, baseContent, {
   },
   errors: {
     ...pick(versionContent.errors, ['awerb', 'awerb-review-date', 'awerb-exempt', 'awerb-dates', 'awerb-no-review-reason'])
+  },
+  refusalNotice: {
+    ...refusalNotice,
+    summaryLabel: 'Show where the reason appears in the refusal notice'
   }
 });

--- a/pages/task/read/content/refusal-notice.js
+++ b/pages/task/read/content/refusal-notice.js
@@ -1,0 +1,58 @@
+const intro = `
+  {{noticeDate}}
+
+  Dear {{licenceHolderName}}
+
+  ### NOTICE OF INTENTION TO REFUSE A LICENCE UNDER ASPA 1986
+
+  Application title: {{projectTitle}}
+`;
+
+const intent = `
+  On behalf of the Secretary of State, I am providing notice of intent to refuse your application as required by
+  [Section 12(1) of the the Animals (Scientific Procedures) Act 1986](https://www.legislation.gov.uk/ukpga/1986/14/section/12#section-12-1)
+  following evaluation under [section 5B of the Act](https://www.legislation.gov.uk/ukpga/1986/14/section/5B) an
+  inspector appointed under [Section 18(1)](https://www.legislation.gov.uk/ukpga/1986/14/section/18#section-18-1)
+  and in accordance with their duty under
+  [Section 18(2[a]) of the Act](https://www.legislation.gov.uk/ukpga/1986/14/section/18#section-18-2).
+
+  It is proposed to refuse your licence application for the following reasons below:
+`;
+
+const representations = `
+  Under [Section 12(3) of the Act](https://www.legislation.gov.uk//ukpga/1986/14/section/12#section-12-3), you have
+  the right to make representations in writing or in person against the Secretary of State's proposal to refuse your
+  application for a licence. Should you wish to make representations to a person appointed by the Secretary of State,
+  you must respond to this notice by {{respondByDate}}. You may give notice of your intention to make representations
+  by contacting your SPoC or emailing [aspa.london@homeoffice.gov.uk](mailto:aspa.london@homeoffice.gov.uk).
+`;
+
+const outro = `
+  Please refer to
+  [Appendix E of the Guidance on the Operation of the Act](https://www.gov.uk/guidance/guidance-on-the-operation-of-the-animals-scientific-procedures-act-1986)
+  for details on the process of making representations.
+
+  Yours sincerely,
+
+  {{inspectorName}}
+`;
+
+const full = `
+  ${intro}
+
+  ${intent}
+
+  > {{refusalReason}}
+
+  ${representations}
+
+  ${outro}
+`;
+
+module.exports = {
+  intro,
+  intent,
+  representations,
+  outro,
+  full
+};

--- a/pages/task/read/content/review.js
+++ b/pages/task/read/content/review.js
@@ -1,0 +1,14 @@
+const { merge } = require('lodash');
+const baseContent = require('./base');
+const refusalNotice = require('./refusal-notice');
+
+module.exports = merge({}, baseContent, {
+  refusalNotice,
+  page: {
+    heading: 'Check notice of intention to refuse',
+    summary: 'This notice will be sent to the applicant and a copy forwarded to the establishment licence holder and admins.'
+  },
+  buttons: {
+    submit: 'Send now'
+  }
+});

--- a/pages/task/read/helpers/declarations.js
+++ b/pages/task/read/helpers/declarations.js
@@ -1,0 +1,31 @@
+const { get } = require('lodash');
+const { render } = require('mustache');
+const content = require('../content/confirm');
+
+const requiresDeclaration = (task, values) => {
+  const model = task.data.model;
+  let action = task.data.action;
+  if (action === 'grant' && task.type === 'amendment') {
+    action = 'update';
+  }
+  if (action === 'grant-ra') {
+    return false;
+  }
+  return ['pil', 'trainingPil', 'project'].includes(model) && values.status === 'endorsed' && action !== 'review';
+};
+
+const trim = value => value.split('\n').map(s => s.trim()).join('\n').trim();
+
+const getDeclarationText = (task, values) => {
+  const declaration = get(content, `declaration.${values.status}.${task.data.model}`);
+  const licenceHolder = get(task, 'data.modelData.profile') || get(task, 'data.modelData.licenceHolder');
+  return trim(render(declaration, {
+    name: `${get(licenceHolder, 'firstName')} ${get(licenceHolder, 'lastName')}`,
+    type: task.type
+  }));
+};
+
+module.exports = {
+  requiresDeclaration,
+  getDeclarationText
+};

--- a/pages/task/read/index.js
+++ b/pages/task/read/index.js
@@ -6,7 +6,7 @@ module.exports = settings => {
   const app = page({
     ...settings,
     root: __dirname,
-    paths: ['/deadline-passed', '/remove-deadline', '/reinstate-deadline', '/extend', '/confirm', '/success', '/endorse']
+    paths: ['/deadline-passed', '/remove-deadline', '/reinstate-deadline', '/extend', '/confirm', '/success', '/endorse', '/review']
   });
 
   app.use('/assign', assign());

--- a/pages/task/read/routers/index.js
+++ b/pages/task/read/routers/index.js
@@ -6,5 +6,6 @@ module.exports = {
   deadlinePassed: require('./deadline-passed'),
   discard: require('./discard'),
   confirm: require('./confirm'),
-  endorse: require('./endorse')
+  endorse: require('./endorse'),
+  review: require('./review')
 };

--- a/pages/task/read/routers/read.js
+++ b/pages/task/read/routers/read.js
@@ -280,6 +280,10 @@ module.exports = () => {
         };
       }
 
+      if (req.task.nextSteps && req.task.nextSteps.length === 1 && req.task.nextSteps[0].id === 'refused') {
+        set(res, 'locals.static.content.buttons.submit', 'Refuse licence');
+      }
+
       next();
     },
     locals: (req, res, next) => {

--- a/pages/task/read/routers/review.js
+++ b/pages/task/read/routers/review.js
@@ -48,7 +48,8 @@ module.exports = () => {
 
     meta.refusalNotice = {
       deadline: moment().add(28, 'days').format('YYYY-MM-DD'),
-      markdown: getRefusalNoticeMarkdown(req.task, req.user.profile, meta.comment)
+      markdown: getRefusalNoticeMarkdown(req.task, req.user.profile, meta.comment),
+      inspectorId: req.user.profile.id
     };
 
     console.log({ values, meta });

--- a/pages/task/read/routers/review.js
+++ b/pages/task/read/routers/review.js
@@ -1,0 +1,75 @@
+const { Router } = require('express');
+const { get } = require('lodash');
+const moment = require('moment');
+const { render } = require('mustache');
+const refusalNoticeContent = require('../content/refusal-notice');
+const { dateFormat } = require('../../../../constants');
+
+const trim = value => value.split('\n').map(s => s.trim()).join('\n').trim();
+
+const getRefusalNoticeMarkdown = (task, inspector, refusalReason) => {
+  const today = moment();
+  const noticeDate = today.format(dateFormat.long);
+  const respondByDate = today.add(28, 'days').format(dateFormat.long);
+  const projectTitle = get(task, 'data.modelData.title');
+  const licenceHolderName = `${get(task, 'data.licenceHolder.firstName')} ${get(task, 'data.licenceHolder.lastName')}`;
+  const inspectorName = `${inspector.firstName} ${inspector.lastName}`;
+
+  return trim(render(refusalNoticeContent.full, {
+    noticeDate,
+    respondByDate,
+    projectTitle,
+    refusalReason,
+    licenceHolderName,
+    inspectorName
+  }));
+};
+
+module.exports = () => {
+  const app = Router();
+
+  app.use((req, res, next) => {
+    const { values, meta } = get(req, `session.form[${req.task.id}]`, {});
+
+    if (values.status !== 'intention-to-refuse') {
+      return res.redirect(req.buildRoute('task.read'));
+    }
+
+    res.locals.static.task = req.task;
+    res.locals.static.inspector = req.user.profile;
+    res.locals.static.refusalReason = meta.comment;
+    res.locals.static.editUrl = req.buildRoute('task.read.confirm');
+
+    next();
+  });
+
+  app.post('/', (req, res, next) => {
+    const { values, meta } = get(req, `session.form[${req.task.id}]`);
+
+    meta.refusalNotice = {
+      deadline: moment().add(28, 'days').format('YYYY-MM-DD'),
+      markdown: getRefusalNoticeMarkdown(req.task, req.user.profile, meta.comment)
+    };
+
+    console.log({ values, meta });
+
+    const opts = {
+      method: 'PUT',
+      headers: { 'Content-type': 'application/json' },
+      json: {
+        data: values,
+        meta
+      }
+    };
+
+    return req.api(`/tasks/${req.task.id}/status`, opts)
+      .then(response => {
+        req.session.success = { taskId: get(response, 'json.data.id') };
+        delete req.session.form[req.model.id];
+        return res.redirect('success');
+      })
+      .catch(next);
+  });
+
+  return app;
+};

--- a/pages/task/read/routers/review.js
+++ b/pages/task/read/routers/review.js
@@ -52,8 +52,6 @@ module.exports = () => {
       inspectorId: req.user.profile.id
     };
 
-    console.log({ values, meta });
-
     const opts = {
       method: 'PUT',
       headers: { 'Content-type': 'application/json' },

--- a/pages/task/read/routes.js
+++ b/pages/task/read/routes.js
@@ -1,4 +1,4 @@
-const { extend, confirm, read, discard, deadlinePassed, endorse, removeDeadline, reinstateDeadline } = require('./routers');
+const { extend, confirm, read, discard, deadlinePassed, endorse, removeDeadline, reinstateDeadline, review } = require('./routers');
 const raAwerb = require('./ra-awerb');
 const success = require('../../success');
 
@@ -40,6 +40,10 @@ module.exports = {
     path: '/endorse',
     breadcrumb: false,
     router: endorse
+  },
+  review: {
+    path: '/review',
+    router: review
   },
   success: {
     path: '/success',

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -303,8 +303,6 @@ export default function ActivityLog({ task }) {
 
   const latestActivity = activityLog[0];
 
-  console.log(latestActivity);
-
   return (
     <div className="activity-log">
       <h2><Snippet>sticky-nav.activity</Snippet></h2>

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -232,6 +232,21 @@ function Comment({ changedBy, comment }) {
   );
 }
 
+function IntentionToRefuse({ task }) {
+  const intentionToRefuse = get(task, 'data.intentionToRefuse');
+
+  if (!intentionToRefuse) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <p><strong>Refusal notice:</strong></p>
+      <Inset><Markdown>{intentionToRefuse.markdown}</Markdown></Inset>
+    </Fragment>
+  );
+}
+
 const showPplDeclarations = (item) => {
   const status = get(item, 'event.status');
   return ['endorsed', 'resubmitted'].includes(status);
@@ -242,6 +257,7 @@ function LogItem({ item, task }) {
   const isExtension = isDeadlineExtension(item);
   const isRa = task.data.action === 'grant-ra';
   const isAssignment = item.eventName === 'assign';
+  const isIntentionToRefuse = action === 'intention-to-refuse';
 
   if (action === 'update') {
     if (isExtension) {
@@ -261,7 +277,8 @@ function LogItem({ item, task }) {
       { isExtension && <DeadlineDetails item={item} /> }
       { isRa && <AwerbDate item={item} /> }
       { isAssignment && <Assignment item={item} />}
-      <Comment changedBy={item.changedBy} comment={item.comment} />
+      { isIntentionToRefuse && <IntentionToRefuse task={task} /> }
+      { !isIntentionToRefuse && <Comment changedBy={item.changedBy} comment={item.comment} /> }
       { showPplDeclarations(item) && <PplDeclarations task={item.event} /> }
       <DeclarationMeta item={item} />
       <ExtraProjectMeta item={item} task={task} />
@@ -285,6 +302,8 @@ export default function ActivityLog({ task }) {
   const activityLog = isAsru ? task.activityLog : task.activityLog.filter(a => a.eventName !== 'assign');
 
   const latestActivity = activityLog[0];
+
+  console.log(latestActivity);
 
   return (
     <div className="activity-log">

--- a/pages/task/read/views/components/refusal-notice-warning.jsx
+++ b/pages/task/read/views/components/refusal-notice-warning.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import get from 'lodash/get';
+import formatDate from 'date-fns/format';
+import { dateFormat } from '../../../../../constants';
+import { Warning } from '@ukhomeoffice/react-components';
+import { Snippet } from '@asl/components';
+
+export default function RefusalNoticeWarning({ task }) {
+  const { isAsru } = useSelector(state => state.static);
+  const intentionToRefuse = get(task, 'data.intentionToRefuse');
+  const today = formatDate(new Date(), 'YYYY-MM-DD');
+
+  if (task.status === 'refused' || !intentionToRefuse || !intentionToRefuse.deadline) {
+    return null;
+  }
+
+  if (intentionToRefuse.deadline < today) {
+    return (
+      <Warning>
+        <Snippet>{`status.intention-to-refuse.warning.${isAsru ? 'passedAsru' : 'passed'}`}</Snippet>
+      </Warning>
+    );
+  }
+
+  const respondBy = formatDate(intentionToRefuse.deadline, dateFormat.long);
+
+  return (
+    <Warning>
+      <Snippet respondBy={respondBy}>{`status.intention-to-refuse.warning.${isAsru ? 'futureAsru' : 'future'}`}</Snippet>
+    </Warning>
+  );
+}

--- a/pages/task/read/views/components/refusal-notice.jsx
+++ b/pages/task/read/views/components/refusal-notice.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import formatDate from 'date-fns/format';
+import addDays from 'date-fns/add_days';
+import classnames from 'classnames';
+import { Inset, Markdown, Snippet } from '@asl/components';
+import { dateFormat } from '../../../../../constants';
+
+export default function RefusalNotice({ project, licenceHolder, inspector, refusalReason, editUrl, dateOfNotice = new Date() }) {
+  const respondBy = addDays(dateOfNotice, 28);
+  const respondByDate = formatDate(respondBy, dateFormat.long);
+  const noticeDate = formatDate(dateOfNotice, dateFormat.long);
+  const licenceHolderName = `${licenceHolder.firstName} ${licenceHolder.lastName}`;
+  const inspectorName = `${inspector.firstName} ${inspector.lastName}`;
+
+  return (
+    <div>
+      <Snippet noticeDate={noticeDate} licenceHolderName={licenceHolderName} projectTitle={project.title}>
+        refusalNotice.intro
+      </Snippet>
+
+      <Snippet linkTarget="_blank">refusalNotice.intent</Snippet>
+
+      <Inset>
+        <div className={classnames('refusal-reason', { highlight: !editUrl })}>
+          {
+            refusalReason
+              ? <Markdown>{refusalReason}</Markdown>
+              : '[Reason for refusal will appear here]'
+          }
+        </div>
+        {
+          editUrl && <p><a href={editUrl} className="govuk-button button-secondary">Edit</a></p>
+        }
+      </Inset>
+
+      <Snippet respondByDate={respondByDate} linkTarget="_blank">refusalNotice.representations</Snippet>
+
+      <Snippet inspectorName={inspectorName} linkTarget="_blank">refusalNotice.outro</Snippet>
+    </div>
+  );
+}

--- a/pages/task/read/views/components/task-status.jsx
+++ b/pages/task/read/views/components/task-status.jsx
@@ -3,10 +3,11 @@ import get from 'lodash/get';
 import classnames from 'classnames';
 import { Snippet } from '@asl/components';
 import Deadline from './deadline';
+import RefusalNoticeWarning from './refusal-notice-warning';
 
 const getStatusBadge = (status, model) => {
   const good = ['resolved'];
-  const bad = ['rejected', 'withdrawn'];
+  const bad = ['rejected', 'withdrawn', 'discarded-by-applicant', 'refused'];
   const className = classnames({ badge: true, complete: good.includes(status) || model === 'rop', rejected: bad.includes(status) });
   return <span className={ className }><Snippet>{ `status.${status}.state` }</Snippet></span>;
 };
@@ -28,6 +29,7 @@ export default function TaskStatus({ task }) {
         {getStatusBadge(status, model)}
         <span className="currently-with"><Snippet optional>{snippetContent}</Snippet></span>
       </p>
+      { model === 'project' && <RefusalNoticeWarning task={task} /> }
       { model === 'project' && <Deadline task={task} /> }
     </div>
   );

--- a/pages/task/read/views/confirm.jsx
+++ b/pages/task/read/views/confirm.jsx
@@ -1,11 +1,12 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Form, Snippet, Header, Link, Field, ErrorSummary } from '@asl/components';
 import get from 'lodash/get';
 import { Button } from '@ukhomeoffice/react-components';
+import RefusalNotice from './components/refusal-notice';
 
-function CommentForm({ formFields, task, errors, values }) {
-  const { requiresDeclaration } = useSelector(state => state.static);
+function CommentForm({ formFields, task, errors, values, comment }) {
+  const { requiresDeclaration, inspector } = useSelector(state => state.static);
   const model = task.data.model;
   let action = task.data.action;
   if (action === 'grant' && task.type === 'amendment') {
@@ -28,6 +29,20 @@ function CommentForm({ formFields, task, errors, values }) {
           content={values.restrictions}
         />
       }
+
+      {
+        values.status === 'intention-to-refuse' &&
+          <details className="gutter">
+            <summary><Snippet>refusalNotice.summaryLabel</Snippet></summary>
+            <RefusalNotice
+              project={get(task, 'data.modelData')}
+              licenceHolder={licenceHolder}
+              inspector={inspector}
+              refusalReason={comment}
+            />
+          </details>
+      }
+
       { formFields }
       { requiresDeclaration &&
         <div className="task-declaration">
@@ -45,11 +60,17 @@ function CommentForm({ formFields, task, errors, values }) {
 
 export default function Confirm() {
   const { task, values, errors } = useSelector(state => state.static);
+  const [comment, setComment] = useState('');
+
+  const onChange = values => {
+    setComment(values.comment);
+  };
+
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        <Form detachFields submit={false}>
-          <CommentForm values={values} task={task} errors={errors} />
+        <Form detachFields submit={false} onChange={onChange}>
+          <CommentForm values={values} task={task} errors={errors} comment={comment} />
         </Form>
       </div>
     </div>

--- a/pages/task/read/views/review.jsx
+++ b/pages/task/read/views/review.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import get from 'lodash/get';
+import { Snippet, Header, Link } from '@asl/components';
+import RefusalNotice from './components/refusal-notice';
+
+export default function Review() {
+  const { task, inspector, refusalReason, editUrl, csrfToken } = useSelector(state => state.static);
+  const licenceHolder = get(task, 'data.modelData.profile') || get(task, 'data.modelData.licenceHolder');
+
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <Header
+          title={<Snippet>page.heading</Snippet>}
+          subtitle={<Snippet>{`tasks.${task.data.model}.${task.data.action}`}</Snippet>}
+        />
+        <p><Snippet>page.summary</Snippet></p>
+
+        <hr />
+
+        <RefusalNotice
+          project={get(task, 'data.modelData')}
+          licenceHolder={licenceHolder}
+          inspector={inspector}
+          refusalReason={refusalReason}
+          editUrl={editUrl}
+        />
+
+        <hr />
+        <form method="POST" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="control-panel">
+            <button type="submit" className="govuk-button"><Snippet>buttons.submit</Snippet></button>
+            <Link page="task.read" label={<Snippet>buttons.cancel</Snippet>} />
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
For project applications, the "rejected" option is now replaced with an "Notify of intention to refuse" which returns the application to the applicant and starts a 28 timer before the project can actually be refused. The full refusal notice is displayed in the task activity log.

Once the timer expires, the application can be refused by an inspector regardless of who the application is currently with. Refused projects will display a red banner on their landing page informing of the project status and the date when the project was refused.

