### PR TITLE
Load named people only when needed

### DIFF
--- a/pages/establishment/dashboard/index.js
+++ b/pages/establishment/dashboard/index.js
@@ -1,11 +1,13 @@
 const { page } = require('@asl/service/ui');
-const { enforcementFlags } = require('../../common/middleware');
+const { enforcementFlags, populateNamedPeople } = require('../../common/middleware');
 
 module.exports = settings => {
   const app = page({
     ...settings,
     root: __dirname
   });
+
+  app.get('/', populateNamedPeople);
 
   app.get('/', (req, res, next) => {
     res.enforcementModel = req.establishment;

--- a/pages/establishment/index.js
+++ b/pages/establishment/index.js
@@ -1,24 +1,19 @@
 const { Router } = require('express');
 const routes = require('./routes');
-const { populateNamedPeople } = require('../common/middleware');
 
 module.exports = settings => {
   const app = Router({ mergeParams: true });
 
-  app.use(
-    (req, res, next) => {
-      req.api(`/establishment/${req.establishmentId}?activeLicenceCounts=true`)
-        .then(response => {
-          req.establishment = response.json.data;
-          req.establishment.openTasks = response.json.meta.openTasks || [];
-          req.establishment.hasActiveLicences = (req.establishment.activePilsCount + req.establishment.activeProjectsCount) > 0;
-        })
-        .then(() => next())
-        .catch(next);
-    }
-  );
-
-  app.use(populateNamedPeople);
+  app.use((req, res, next) => {
+    req.api(`/establishment/${req.establishmentId}`)
+      .then(response => {
+        req.establishment = response.json.data;
+        req.establishment.openTasks = response.json.meta.openTasks || [];
+        req.establishment.hasActiveLicences = (req.establishment.activePilsCount + req.establishment.activeProjectsCount) > 0;
+      })
+      .then(() => next())
+      .catch(next);
+  });
 
   app.use((req, res, next) => {
     res.locals.static.profile = req.user.profile;

--- a/pages/establishment/pdf/index.jsx
+++ b/pages/establishment/pdf/index.jsx
@@ -7,6 +7,7 @@ import groupBy from 'lodash/groupBy';
 import Body from './views';
 import Header from '../../common/views/pdf/header';
 import Footer from '../../common/views/pdf/footer';
+import { populateNamedPeople } from '../../common/middleware';
 import content from './content';
 import PDF from '../../common/helpers/pdf';
 
@@ -25,6 +26,8 @@ const stateReducer = (state = {}) => state;
 module.exports = settings => {
   const app = Router({ mergeParams: true });
   const pdf = PDF(settings);
+
+  app.get('/', populateNamedPeople);
 
   app.get('/', (req, res, next) => {
     const establishment = {

--- a/pages/establishment/read/index.js
+++ b/pages/establishment/read/index.js
@@ -3,7 +3,8 @@ const moment = require('moment');
 const { get } = require('lodash');
 const { page } = require('@asl/service/ui');
 const { form, relatedTasks } = require('../../common/routers');
-const { enforcementFlags } = require('../../common/middleware');
+const { enforcementFlags, populateNamedPeople } = require('../../common/middleware');
+
 const schema = require('./schema');
 
 module.exports = settings => {
@@ -46,6 +47,8 @@ module.exports = settings => {
       next();
     }
   }));
+
+  app.get('/', populateNamedPeople);
 
   app.get('/', (req, res, next) => {
     res.enforcementModel = req.establishment;


### PR DESCRIPTION
There is an API call to `GET /establishment/:id` on every page load, which was previously loading the establishment's named people even though these were only used in a small handful of places.

In order to speed up the API calls this has been removed from the API response and split into its own endpoint which is called only on the pages where the named people are needed - specifically the establishment landing page, details page, and PDF download.