### PR TITLE
Fix redirects to open task

### DIFF
--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -60,7 +60,7 @@ module.exports = () => {
 
     if (returnTo) {
       // preserve http method
-      return res.redirect(307, values.returnTo);
+      return res.redirect(307, returnTo);
     }
     next();
   });


### PR DESCRIPTION
The condition was checking the value of `returnTo`, but then redirecting to `values.returnTo` which is undefined, and so was redirecting to a URL that threw a 404.

Bug was introduced [here](https://github.com/UKHomeOffice/asl-pages/commit/831b11ebf2c9f8ed28326c8223a8015e29286167#diff-3eb53d7029005013e62eefa22e319f2cdcd923f1ba4861db5a7e12c3e3b6b9b7L73-R61)