### PR TITLE
ASL-2017 - Save PIL training answer on task

### DIFF
--- a/pages/pil/dashboard/index.js
+++ b/pages/pil/dashboard/index.js
@@ -15,7 +15,7 @@ module.exports = settings => {
     const opts = {
       method: 'PUT',
       json: merge({
-        data: pick(req.model, 'procedures', 'notesCatD', 'notesCatF', 'species'),
+        data: pick(req.model, 'procedures', 'notesCatD', 'notesCatF', 'species', 'training'),
         meta: {
           declaration: content.fields.declaration.label
         }
@@ -60,7 +60,7 @@ module.exports = settings => {
       .filter(e => e.id !== req.establishment.id)
       .find(e => e.id === get(req.model, 'establishmentId'));
 
-    const trainingUpToDate = get(req.session, `form[${req.model.id}-training].values.update`) === false;
+    const trainingUpToDate = get(req.model, `training.update`) === false;
     res.locals.static.trainingUpToDate = trainingUpToDate;
 
     req.model.establishment = {

--- a/pages/pil/training/index.js
+++ b/pages/pil/training/index.js
@@ -1,4 +1,4 @@
-const { set } = require('lodash');
+const { set, get } = require('lodash');
 const { page } = require('@asl/service/ui');
 const { form } = require('../../common/routers');
 const { buildModel } = require('../../../lib/utils');
@@ -21,6 +21,9 @@ module.exports = settings => {
     const { update } = req.form.values;
 
     if (!update) {
+      const training = get(req.session, `form[${req.model.id}].values`);
+      const savedValues = get(req.session, `form[${req.pil.id}].values`);
+      set(req.session, `form[${req.pil.id}].values`, Object.assign({}, savedValues, { training: training }));
       return res.redirect(req.buildRoute('pil.update'));
     }
     const type = req.pil.status === 'active' ? 'amendment' : 'application';


### PR DESCRIPTION
This now stores the `Do you need to update this training record?` answer on the training page on the task as: `"training": {"update": false}`

This then allows the edit and resubmit page to use this to display the training summary and completed status label rather than the answer in the session.