### PR TITLE
Redirect to task page with error message if processing fails

### DIFF
--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -220,7 +220,8 @@ module.exports = {
     }
   },
   notifications: {
-    success: 'Changes saved.'
+    success: 'Changes saved.',
+    'form-session-error': 'There was a problem processing this form. Please try again.'
   },
   warnings: {
     openTask: 'This item is currently being edited'

--- a/pages/task/read/routers/confirm.js
+++ b/pages/task/read/routers/confirm.js
@@ -24,9 +24,15 @@ module.exports = () => {
     configure: (req, res, next) => {
       const chosenStatus = get(req, `session.form[${req.task.id}].values.status`);
       if (!chosenStatus) {
+        req.notification({ key: 'form-session-error', type: 'error' });
         return res.redirect(req.buildRoute('task.read'));
       }
-      res.locals.static.commentRequired = req.task.nextSteps.find(s => s.id === chosenStatus).commentRequired;
+      const nextStep = req.task.nextSteps.find(s => s.id === chosenStatus);
+      if (!nextStep) {
+        req.notification({ key: 'form-session-error', type: 'error' });
+        return res.redirect(req.buildRoute('task.read'));
+      }
+      res.locals.static.commentRequired = nextStep.commentRequired;
       res.locals.static.commentLabel = content.commentLabels[chosenStatus];
       req.schema = getSchema({ task: req.task, chosenStatus });
       req.form.schema = req.schema;


### PR DESCRIPTION
The the user tries to submit a task with a status that is no longer valid (i.e. it's been processed in another tab etc so the target status doesn't apply anymore) then redirect back to the task with an error notification rather than leaving the user on an error page.