### PR TITLE
Prevent sorting on PIL status in establishment people lists

### DIFF
--- a/pages/profile/list/schema/index.js
+++ b/pages/profile/list/schema/index.js
@@ -45,6 +45,7 @@ module.exports = {
   },
   pilStatus: {
     show: true,
+    sortable: false,
     toCSVString: (_, row) => {
       if (!row.pil) {
         return '';


### PR DESCRIPTION
Attempting to sort by PIL status currently throws an error because there is no corresponding database column `pil_status` on the profiles table.

Supporting an _actual_ sort given the way statuses are mapped (with particular reference to `suspended`) is non-trivial, so to prevent the error disable sorting.