### PR TITLE
Add error message for unsupported image types

### DIFF
--- a/pages/project-version/docx/index.js
+++ b/pages/project-version/docx/index.js
@@ -38,6 +38,7 @@ const loadImages = attachmentHost => async node => {
   if (!url) {
     return node;
   }
+  // url is in the format data:image/type; so we use characters between index 11 and ; as the file type
   const imageType = url.substring(11, url.indexOf(';'));
   if (imageType === 'png' || imageType === 'jpeg') {
     const src = url.substring(url.indexOf(',') + 1);

--- a/pages/project-version/docx/index.js
+++ b/pages/project-version/docx/index.js
@@ -38,7 +38,7 @@ const loadImages = attachmentHost => async node => {
   if (!url) {
     return node;
   }
-  // url is in the format data:image/type; so we use characters between index 11 and ; as the file type
+  // url starts with the format data:image/type; so we use characters between index 11 and ; as the file type
   const imageType = url.substring(11, url.indexOf(';'));
   if (imageType === 'png' || imageType === 'jpeg') {
     const src = url.substring(url.indexOf(',') + 1);

--- a/pages/project-version/docx/index.js
+++ b/pages/project-version/docx/index.js
@@ -38,19 +38,27 @@ const loadImages = attachmentHost => async node => {
   if (!url) {
     return node;
   }
-  const src = url.substring(url.indexOf(',') + 1);
-  const buffer = Buffer.from(src, 'base64');
-  let dimensions = imageSize(buffer);
-  dimensions = scaleAndPreserveAspectRatio(
-    dimensions.width,
-    dimensions.height,
-    MAX_IMAGE_WIDTH,
-    MAX_IMAGE_HEIGHT
-  );
-  node.data.width = dimensions.width;
-  node.data.height = dimensions.height;
-  node.data.src = url;
-  return node;
+  const imageType = url.substring(11, url.indexOf(';'));
+  if (imageType === 'png' || imageType === 'jpeg') {
+    const src = url.substring(url.indexOf(',') + 1);
+    const buffer = Buffer.from(src, 'base64');
+    let dimensions = imageSize(buffer);
+    dimensions = scaleAndPreserveAspectRatio(
+      dimensions.width,
+      dimensions.height,
+      MAX_IMAGE_WIDTH,
+      MAX_IMAGE_HEIGHT
+    );
+    node.data.width = dimensions.width;
+    node.data.height = dimensions.height;
+    node.data.src = url;
+    return node;
+  } else {
+    return {
+      type: 'error',
+      nodes: [ { text: 'Image type unsupported. Please use a JPG or PNG image for DOCX exports.', marks: [], object: 'text' } ]
+    };
+  }
 };
 
 module.exports = (settings) => {


### PR DESCRIPTION
- Only attempt to load images which are PNG or JPEG files
- All other image types load an error message

<img width="564" alt="Screenshot 2022-09-21 at 17 48 05" src="https://user-images.githubusercontent.com/61828376/191564081-2dd94dd1-f33b-4b78-8c50-1205d9023854.png">

