### PR TITLE
ASL-4046 - Allow retrieving a node by path within an object by UUID

### DIFF
--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -126,10 +126,8 @@ const getNode = (tree, path) => {
     if (!parent) {
       return;
     }
-    if (isUUID(keys[i])) {
-      if (parent instanceof Array) {
-        node = parent.find(o => o.id === keys[i]);
-      }
+    if (parent instanceof Array && isUUID(keys[i])) {
+      node = parent.find(o => o.id === keys[i]);
     } else {
       node = parent[keys[i]];
     }


### PR DESCRIPTION
This will allow path to reference objects with UUID as property keys for diff comparison, for example:

The path `reusableSteps.8656ff4b-fd16-4c60-9cd8-eb72dcd26989.title` should work on the following JSON structure

`
{
  "reusableSteps": {
    "8656ff4b-fd16-4c60-9cd8-eb72dcd26989": {
      "title": "some title",
      ...
    }
  }
}
`