### PR TITLE
Add block class to fix formatting in larger table

### DIFF
--- a/pages/task/list/components/assign-task.jsx
+++ b/pages/task/list/components/assign-task.jsx
@@ -44,7 +44,7 @@ export default function AssignTask({ task }) {
 
   return (
     <Fragment>
-      <em>Unassigned</em>
+      <em className="block">Unassigned</em>
       <button className="link" disabled={disabled} onClick={assignToMe}><span>Assign to me</span></button>
     </Fragment>
   );


### PR DESCRIPTION
Give 'unassigned' block formatting so it stays on its own line no matter how big the table cell is

<img width="273" alt="Screenshot 2022-10-26 at 11 28 15" src="https://user-images.githubusercontent.com/61828376/198003467-6bd48fa4-a33d-4c9c-8781-dafc0efef8ce.png">
