### PR TITLE
ASSB-1258: Fix resubmission of place amendments

### DIFF
--- a/pages/place/routers/confirm.js
+++ b/pages/place/routers/confirm.js
@@ -11,7 +11,7 @@ module.exports = settings => {
     const opts = {
       method: settings.method,
       json: merge({
-        data: omit(values, 'comments', 'comment', 'establishmentId', 'changesToRestrictions', 'nacwos', 'nvssqps'),
+        data: omit(values, 'comments', 'comment', 'establishmentId', 'changesToRestrictions', 'nacwos', 'nvssqps', 'conditions', 'reminder'),
         meta: {
           ...pick(values, 'comments', 'changesToRestrictions')
         }


### PR DESCRIPTION
Conditions and reminders data from the task was being sent to public-api as part of the place amendment which was causing an error as it is not whitelisted
Stop sending conditions and reminders data from the task 