### PR TITLE
Fix default condition appearing when condition is removed from task

### DIFF
--- a/pages/task/read/views/models/establishment.jsx
+++ b/pages/task/read/views/models/establishment.jsx
@@ -20,6 +20,10 @@ export default function Establishment({ task, values }) {
   const canUpdateConditions = allowedActions.includes('establishment.updateConditions');
   const taskData = task.data.data;
 
+  if (!taskData.conditions && taskData.conditions !== '') {
+    taskData.conditions = establishment.conditions;
+  }
+
   return [
     (
       task.type === 'application' && (
@@ -59,7 +63,7 @@ export default function Establishment({ task, values }) {
           <div className="sticky-nav-anchor">
             <h2><Snippet>conditions.title</Snippet></h2>
             <Conditions
-              conditions={taskData.conditions ? taskData.conditions : establishment.conditions }
+              conditions={taskData.conditions}
               reminders={taskData.reminder && taskData.reminder !== '' ? [JSON.parse(taskData.reminder)] : establishment.reminders}
               label={<Snippet>conditions.hasConditions</Snippet>}
               noConditionsLabel={<Snippet>conditions.noConditions</Snippet>}

--- a/pages/task/read/views/models/place.jsx
+++ b/pages/task/read/views/models/place.jsx
@@ -26,6 +26,10 @@ export default function Playback({ task, values, allowSubmit }) {
   const canUpdateConditions = allowedActions.includes('establishment.updateConditions');
   const taskData = task.data.data;
 
+  if (!taskData.conditions && taskData.conditions !== '') {
+    taskData.conditions = establishment.conditions;
+  }
+
   const isComplete = !task.isOpen;
 
   useEffect(() => {
@@ -105,7 +109,7 @@ export default function Playback({ task, values, allowSubmit }) {
       <StickyNavAnchor id="conditions" key="conditions">
         <h2><Snippet>conditions.title</Snippet></h2>
         <Conditions
-          conditions={taskData.conditions ? taskData.conditions : establishment.conditions }
+          conditions={taskData.conditions}
           reminders={taskData.reminder && taskData.reminder !== '' ? [JSON.parse(taskData.reminder)] : establishment.reminders}
           label={<Snippet>conditions.hasConditions</Snippet>}
           noConditionsLabel={<Snippet>conditions.noConditions</Snippet>}

--- a/pages/task/read/views/models/role.jsx
+++ b/pages/task/read/views/models/role.jsx
@@ -15,6 +15,10 @@ export default function Role({ task, values, schema }) {
   const canUpdateConditions = allowedActions.includes('establishment.updateConditions');
   const taskData = task.data.data;
 
+  if (!taskData.conditions && taskData.conditions !== '') {
+    taskData.conditions = establishment.conditions;
+  }
+
   return [
     (
       task.data.action === 'create' && (
@@ -104,7 +108,7 @@ export default function Role({ task, values, schema }) {
       <StickyNavAnchor id="conditions" key="conditions">
         <h2><Snippet>conditions.title</Snippet></h2>
         <Conditions
-          conditions={taskData.conditions ? taskData.conditions : establishment.conditions }
+          conditions={taskData.conditions}
           reminders={taskData.reminder && taskData.reminder !== '' ? [JSON.parse(taskData.reminder)] : establishment.reminders}
           label={<Snippet>conditions.hasConditions</Snippet>}
           noConditionsLabel={<Snippet>conditions.noConditions</Snippet>}


### PR DESCRIPTION
Previously when a condition was removed it would load the condition that is saved to the establishment, rather than a blank condition as the conditional would be negative because taskData.condition was blank.
Adds the establishment condition to the task data if there is not one on the task and always loads the condition from the task, fixes issue.