### PR TITLE
[ASL-4299] use hba filename

### DIFF
--- a/pages/project/read/views/components/current-version.jsx
+++ b/pages/project/read/views/components/current-version.jsx
@@ -80,7 +80,7 @@ export default function CurrentVersion() {
       </p>
       {version.hbaToken && (
         <p>
-          <a href={`/attachment/${version.hbaToken}`}>
+          <a href={`/attachment/${version.hbaToken}`} download={`${version.hbaFilename}`}>
             <Snippet>otherDocuments.links.hba</Snippet>
           </a>
         </p>

--- a/pages/project/read/views/sections/downloads.jsx
+++ b/pages/project/read/views/sections/downloads.jsx
@@ -240,7 +240,7 @@ function DownloadSection({ project, version }) {
             <Snippet>downloads.hba.hint</Snippet>
           </p>
           <p>
-            <a href={`/attachment/${version.hbaToken}`}>
+            <a href={`/attachment/${version.hbaToken}`} download={`${version.hbaFilename}`}>
               <Snippet>downloads.hba.link</Snippet>
             </a>
           </p>

--- a/pages/task/read/routers/confirm-hba.js
+++ b/pages/task/read/routers/confirm-hba.js
@@ -66,7 +66,7 @@ module.exports = (config) => {
         )
         .catch(next);
     } else if (confirmHba === 'yes') {
-      const { hbaToken } = req.session.form[req.task.id].values;
+      const { hbaToken, hbaFilename } = req.session.form[req.task.id].values;
 
       if (!hbaToken) {
         return next(new Error('Missing HBA token'));
@@ -76,7 +76,8 @@ module.exports = (config) => {
         headers: { 'Content-type': 'application/json' },
         json: {
           data: {
-            hbaToken
+            hbaToken,
+            hbaFilename
           }
         }
       };

--- a/pages/task/read/views/components/activity-log.jsx
+++ b/pages/task/read/views/components/activity-log.jsx
@@ -222,6 +222,7 @@ function ExtraProjectMeta({ item, task }) {
   const isEndorsed = isTrueish(get(item, 'event.data.meta.authority'));
   const isAwerbed = isTrueish(get(item, 'event.data.meta.awerb'));
   const hbaToken = get(item, 'event.data.meta.hbaToken');
+  const hbaFilename = get(item, 'event.data.meta.hbaFilename');
   const requiresAdminInteraction =
     !isEndorsed || (!isAwerbed && !actionPerformedByAdmin(item));
 
@@ -270,9 +271,9 @@ function ExtraProjectMeta({ item, task }) {
             }
           />
         </p>
-        {isAsru && hbaToken && (
+        {isAsru && hbaToken && hbaFilename && (
           <p>
-            <a href={`/attachment/${hbaToken}`}>
+            <a href={`/attachment/${hbaToken}`} download={`${hbaFilename}`}>
               <Snippet>view.hba</Snippet>
             </a>
           </p>

--- a/pages/task/read/views/confirm-hba.jsx
+++ b/pages/task/read/views/confirm-hba.jsx
@@ -42,7 +42,7 @@ const ConfirmHba = ({ establishment, licenceHolder, hba, task }) => {
             <Snippet>fields.hbaFilename.label</Snippet>
           </strong>
           <br />
-          <a href={`/attachment/${hba.hbaToken}`}>{hba.hbaFilename}</a>{' '}
+          <a href={`/attachment/${hba.hbaToken}`} download={`${hba.hbaFilename}`}>{hba.hbaFilename}</a>{' '}
         </p>
         <Warning>
           <Snippet>warning</Snippet>

--- a/pages/task/read/views/confirm.jsx
+++ b/pages/task/read/views/confirm.jsx
@@ -49,7 +49,7 @@ function CommentForm({ formFields, task, errors, values, comment }) {
             <Snippet>hba</Snippet>
           </label>
           <p>
-            <a href={`/attachment/${hbaToken}`}>{hbaFilename}</a>
+            <a href={`/attachment/${hbaToken}`} download={`${hbaFilename}`}>{hbaFilename}</a>
           </p>
         </>
       )}

--- a/pages/task/read/views/upload-hba.jsx
+++ b/pages/task/read/views/upload-hba.jsx
@@ -30,7 +30,7 @@ const UploadHba = ({ hba, task }) => {
               <Snippet>fields.hba.label</Snippet>
             </strong>
             <br />
-            <a href={`/attachment/${hba.hbaToken}`}>{hba.hbaFilename}</a>{' '}
+            <a href={`/attachment/${hba.hbaToken}`} download={`${hba.hbaFilename}`}>{hba.hbaFilename}</a>{' '}
           </p>
         )}
       </Form>


### PR DESCRIPTION
Adds hba filename as suggested download title on hba download links

<img width="644" alt="Screenshot 2023-07-19 at 14 53 23" src="https://github.com/UKHomeOffice/asl-pages/assets/120181/aa963c29-2c22-48f2-8084-2c4ad2740754">

**Suggested download title matches upload title**

<img width="349" alt="Screenshot 2023-07-19 at 14 53 27" src="https://github.com/UKHomeOffice/asl-pages/assets/120181/cb6269af-23a6-4206-85d2-4fa0efac3359">
