### PR TITLE
Feature/asl 4390 fix typo

### DIFF
--- a/pages/task/read/content/confirm-hba.js
+++ b/pages/task/read/content/confirm-hba.js
@@ -20,14 +20,13 @@ module.exports = merge({}, baseContent, {
     confirmHba: {
       label: 'What do you want to do?',
       options: {
-        yes: 'Confirm and continue to grant licence',
-        yesAmend: 'Confirm and continue to amend licence',
+        yes: 'Confirm and continue to grant or amend licence',
         no: 'Discard selected file and choose another'
       }
     }
   },
   warning:
-    'Once confirmed, this HBA file in ASPeL (not SharePoint) will be the single point of reference for this {{type}}, for future assessment and audit purposes',
+    'Once confirmed, this HBA file in ASPeL (not SharePoint) will be the single point of reference for this {{type}}, for future assessment and audit purposes.',
   errors: {
     confirmHba: {
       required: 'Select an option',

--- a/pages/task/read/content/confirm-hba.js
+++ b/pages/task/read/content/confirm-hba.js
@@ -27,7 +27,7 @@ module.exports = merge({}, baseContent, {
     }
   },
   warning:
-    'Once confirmed, this HBA file in ASPeL (not SharePoint) will be the single point of reference for this application, for future assessment and audit purposes',
+    'Once confirmed, this HBA file in ASPeL (not SharePoint) will be the single point of reference for this {{type}}, for future assessment and audit purposes',
   errors: {
     confirmHba: {
       required: 'Select an option',

--- a/pages/task/read/content/upload-hba.js
+++ b/pages/task/read/content/upload-hba.js
@@ -11,7 +11,7 @@ module.exports = merge({}, baseContent, {
   fields: {
     upload: {
       label: 'Upload {{#model.hbaToken}}new {{/model.hbaToken}}file',
-      hint: "You can review and confirm the file you've chosen before granting the licence. You can also update the file in the future, if required."
+      hint: "You can review and confirm the file you've chosen before {{model.action}}ing the licence. You can also update the file in the future, if required."
     },
     hba: {
       label: 'Selected harm benefit analysis file'

--- a/pages/task/read/routers/upload-hba.js
+++ b/pages/task/read/routers/upload-hba.js
@@ -5,6 +5,7 @@ const { form } = require('../../../common/routers');
 const schema = require('../../schema/upload-hba');
 const FormData = require('form-data');
 const { default: axios } = require('axios');
+const { getActionAdjustedWording } = require('../views/adjusted-wording');
 
 module.exports = (config) => {
   const app = Router({ mergeParams: true });
@@ -55,6 +56,7 @@ module.exports = (config) => {
           });
           req.form.values.hbaToken = data.token;
           req.form.values.hbaFilename = file.originalname;
+          req.form.values.action = getActionAdjustedWording(req.task.data.action, req.task.type);
           next();
         } catch (error) {
           return next(error);

--- a/pages/task/read/routers/upload-hba.js
+++ b/pages/task/read/routers/upload-hba.js
@@ -38,6 +38,7 @@ module.exports = (config) => {
       locals(req, res, next) {
         res.locals.static.establishment = req.establishment;
         res.locals.static.task = req.task;
+        req.form.values.action = getActionAdjustedWording(req.task.data.action, req.task.type);
         next();
       },
       process: async (req, res, next) => {
@@ -56,7 +57,6 @@ module.exports = (config) => {
           });
           req.form.values.hbaToken = data.token;
           req.form.values.hbaFilename = file.originalname;
-          req.form.values.action = getActionAdjustedWording(req.task.data.action, req.task.type);
           next();
         } catch (error) {
           return next(error);

--- a/pages/task/read/views/adjusted-wording.js
+++ b/pages/task/read/views/adjusted-wording.js
@@ -1,0 +1,17 @@
+const getActionAdjustedWording = (action, type) => {
+  return isAmendment(action, type) ? 'amend' : action;
+};
+
+const getTypeAdjustedWording = (action, type) => {
+  return isAmendment(action, type) ? 'amendment' : 'application';
+};
+
+const isAmendment = (action, type) => {
+  return action === 'grant' && type === 'amendment';
+};
+
+module.exports = {
+  getActionAdjustedWording,
+  getTypeAdjustedWording,
+  isAmendment
+};

--- a/pages/task/read/views/confirm-hba.jsx
+++ b/pages/task/read/views/confirm-hba.jsx
@@ -8,10 +8,12 @@ import {
   ErrorSummary
 } from '@ukhomeoffice/asl-components';
 import { Warning } from '../../../common/components/warning';
+import { getTypeAdjustedWording, isAmendment } from './adjusted-wording';
 
 const ConfirmHba = ({ establishment, licenceHolder, hba, task }) => {
   let action = task.data.action;
-  if (action === 'grant' && task.type === 'amendment') {
+  const uploadType = getTypeAdjustedWording(action, task.type);
+  if (isAmendment(action, task.type)) {
     action = 'update';
   }
   return (
@@ -45,7 +47,7 @@ const ConfirmHba = ({ establishment, licenceHolder, hba, task }) => {
           <a href={`/attachment/${hba.hbaToken}`} download={`${hba.hbaFilename}`}>{hba.hbaFilename}</a>{' '}
         </p>
         <Warning>
-          <Snippet>warning</Snippet>
+          <Snippet type={uploadType}>warning</Snippet>
         </Warning>
       </Form>
     </WidthContainer>

--- a/pages/task/read/views/upload-hba.jsx
+++ b/pages/task/read/views/upload-hba.jsx
@@ -7,15 +7,18 @@ import {
   WidthContainer,
   ErrorSummary
 } from '@ukhomeoffice/asl-components';
+import {
+  getActionAdjustedWording,
+  getTypeAdjustedWording,
+  isAmendment
+} from './adjusted-wording';
 
 const UploadHba = ({ hba, task }) => {
   let action = task.data.action;
-  let uploadAction = action;
-  let uploadType = 'application';
-  if (action === 'grant' && task.type === 'amendment') {
+  const uploadAction = getActionAdjustedWording(action, task.type);
+  const uploadType = getTypeAdjustedWording(action, task.type);
+  if (isAmendment(action, task.type)) {
     action = 'update';
-    uploadAction = 'amend';
-    uploadType = 'amendment';
   }
   return (
     <WidthContainer>


### PR DESCRIPTION
This an increment to this already-merged PR https://github.com/UKHomeOffice/asl-pages/pull/1563 to:
- Fill a few gaps where the amend wording was missed
- Use generic wording, exceptionally in the confirm radio button component, due to UI component design limitation (Refer to [this ticket](https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4400) for more details)
- Extract logic for adjusted wording into function for reusability