### PR TITLE
Bugfix/assb 1345 without diff window regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/pages",
-  "version": "30.2.5",
+  "version": "30.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/pages",
-      "version": "30.2.5",
+      "version": "30.2.6",
       "license": "MIT",
       "dependencies": {
         "@asl/dictionary": "^1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@asl/dictionary": "^1.1.5",
-        "@asl/projects": "^14.1.1",
+        "@asl/projects": "^14.1.5",
         "@asl/service": "^10.0.0",
         "@joefitter/docx": "^4.7.0",
         "@ukhomeoffice/asl-components": "12.0.0",
@@ -88,9 +88,9 @@
       "license": "MIT"
     },
     "node_modules/@asl/projects": {
-      "version": "14.1.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-14.1.1.tgz",
-      "integrity": "sha512-G8L3r1YUXIuM5klEg1pry8fBYSpa3JBWKhWWJ96tri9xGppwQf03e8vU3EA7cLVNVB7A4j3k2jQaIkioFTmf7A==",
+      "version": "14.1.5",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-14.1.5.tgz",
+      "integrity": "sha512-qVAzqk96Iy1xkDs9QmG+B3QQckdMEFJ7ZMJ/AXin+FTk3PINsf8+JasEzX+faqhMACyyDlOkfgVw81mngDaRGw==",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.0.0",
@@ -109,6 +109,7 @@
         "immutable": "^3.8.2",
         "is-hotkey": "^0.2.0",
         "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^7.2.0",
         "lodash": "^4.17.21",
         "mdn-polyfills": "^5.15.0",
         "minimatch": "^3.0.4",
@@ -10098,6 +10099,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -16053,9 +16062,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/projects": {
-      "version": "14.1.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-14.1.1.tgz",
-      "integrity": "sha512-G8L3r1YUXIuM5klEg1pry8fBYSpa3JBWKhWWJ96tri9xGppwQf03e8vU3EA7cLVNVB7A4j3k2jQaIkioFTmf7A==",
+      "version": "14.1.5",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-14.1.5.tgz",
+      "integrity": "sha512-qVAzqk96Iy1xkDs9QmG+B3QQckdMEFJ7ZMJ/AXin+FTk3PINsf8+JasEzX+faqhMACyyDlOkfgVw81mngDaRGw==",
       "requires": {
         "@asl/service": "^10.0.0",
         "@asl/slate-edit-table": "0.0.3",
@@ -16073,6 +16082,7 @@
         "immutable": "^3.8.2",
         "is-hotkey": "^0.2.0",
         "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^7.2.0",
         "lodash": "^4.17.21",
         "mdn-polyfills": "^5.15.0",
         "minimatch": "^3.0.4",
@@ -23861,6 +23871,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
+    },
+    "jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
     },
     "jsprim": {
       "version": "1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/pages",
-  "version": "30.2.4",
+  "version": "30.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/pages",
-      "version": "30.2.4",
+      "version": "30.2.5",
       "license": "MIT",
       "dependencies": {
         "@asl/dictionary": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-pages#readme",
   "dependencies": {
     "@asl/dictionary": "^1.1.5",
-    "@asl/projects": "^14.1.1",
+    "@asl/projects": "^14.1.5",
     "@asl/service": "^10.0.0",
     "@joefitter/docx": "^4.7.0",
     "@ukhomeoffice/asl-components": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/pages",
-  "version": "30.2.4",
+  "version": "30.2.5",
   "description": "",
   "main": "index.js",
   "style": "pages/common/assets/sass/style.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/pages",
-  "version": "30.2.5",
+  "version": "30.2.6",
   "description": "",
   "main": "index.js",
   "style": "pages/common/assets/sass/style.scss",

--- a/pages/project-version/middleware/index.js
+++ b/pages/project-version/middleware/index.js
@@ -120,6 +120,10 @@ const getNode = (tree, path) => {
     return establishment && (establishment.name || establishment['establishment-name']);
   }
   let keys = path.split('.');
+  if (path.match(/protocols\.(.*)\.reusableSteps\./)) {
+    const position = path.lastIndexOf('reusableSteps.');
+    keys = path.substring(position).split('.');
+  }
   let node = tree[keys[0]];
   for (let i = 1; i < keys.length; i++) {
     let parent = node;


### PR DESCRIPTION
Make asl-pages use the asl-projects npm package version which has the bugfix.
Also a workaround was necessary be the reusable step field key has "protocols." prefix but the actual project data is stored under "reusableSteps" JSON key.
