### PR TITLE
[ASL-4474] Content changes to move to required fields

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -8,10 +8,10 @@ function getRopsYears(start) {
 
 module.exports = {
   dateFormat: {
-    short: 'DD/MM/YYYY',
+    short: 'D/M/YYYY',
     medium: 'D MMM YYYY',
-    long: 'DD MMMM YYYY',
-    datetime: 'DD MMMM YYYY HH:mm'
+    long: 'D MMMM YYYY',
+    datetime: 'D MMMM YYYY HH:mm'
   },
   ropsYears: getRopsYears(2021)
 };

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -13,7 +13,7 @@ const defaultValidators = [
   }
 ];
 
-const validateField = (key, { value, validate }, fields, model) => {
+const validateField = (key, { value, validate = [] }, fields, model) => {
   return validate.reduce((err, options) => {
     const { validator, params } = options;
     return err || (!validators[validator](key, value, params, fields, model) && validator);
@@ -32,6 +32,7 @@ const validate = (fields, model) => {
 
 const normaliseValidators = field => {
   if (!field.validate) {
+    field.validate = [];
     return field;
   }
   return {
@@ -52,7 +53,7 @@ const normaliseValidators = field => {
   };
 };
 
-const mapDefaults = (field, key) => {
+const mapDefaults = (field) => {
   const defaults = (defaultValidators.find(v => v.inputType === field.inputType) || {}).validate;
   return {
     ...field,
@@ -69,9 +70,9 @@ const middleware = (values, schema, model) => {
     .mapValues(mapDefaults)
     .pickBy((field, key) => {
       if (!field.conditionalReveal) {
-        return field.validate;
+        return true;
       }
-      return values[`conditional-reveal-${key}`] === 'true' && field.validate;
+      return values[`conditional-reveal-${key}`] === 'true';
     })
     .value();
 

--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -204,14 +204,14 @@ module.exports = {
     }
   },
   errors: {
-    heading: 'Please fix the following error',
-    headingPlural: 'Please fix the following errors',
+    heading: 'There is a problem',
+    headingPlural: 'There is a problem',
     form: {
       unchanged: 'No changes have been made',
       csrf: 'This form data has been changed somewhere else.'
     },
     declaration: {
-      required: 'Please confirm that you understand.'
+      required: 'Select to confirm that you understand.'
     },
     default: {
       maxLength: 'This field is limited to 256 characters',

--- a/pages/common/routers/form.js
+++ b/pages/common/routers/form.js
@@ -198,7 +198,14 @@ const schemaWithReveals = (schema) =>
       return {
         ...obj,
         [key]: value,
-        ...(value.reveal || {})
+        ...(value.reveal || {}),
+        ...(value.options || []).reduce(
+          (acc, opt) => ({
+            ...acc,
+            ...(opt.reveal ? schemaWithReveals(opt.reveal) : {})
+          }),
+          {}
+        )
       };
     },
     {}
@@ -242,11 +249,11 @@ module.exports = ({
   process = defaultMiddleware,
   validate = defaultMiddleware,
   saveValues = defaultMiddleware,
-  requiresDeclaration = (req) => false,
-  cancelEdit = (req, res, next) => {
+  requiresDeclaration = () => false,
+  cancelEdit = (req, res) => {
     return res.redirect(cancelPath);
   },
-  editAnswers = (req, res, next) => {
+  editAnswers = (req, res) => {
     return res.redirect(req.baseUrl.replace(/\/confirm/, ''));
   }
 } = {}) => {

--- a/pages/establishment/licence-fees/content/index.js
+++ b/pages/establishment/licence-fees/content/index.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   fees: {
     title: 'Estimated licence fees',
-    period: 'Covering the period:',
+    period: 'Covering the financial year:',
     disclaimer: 'These projections are based on the number of billable licences held and may differ from the final numbers.',
     details: {
       summary: 'How these fees are calculated',

--- a/pages/establishment/licence-fees/details/content/index.js
+++ b/pages/establishment/licence-fees/details/content/index.js
@@ -5,22 +5,58 @@ module.exports = merge({}, content, {
   title: 'Contact information for billing',
   fields: {
     contactName: {
-      label: 'Billing contact'
+      label: 'Billing contact name'
     },
     contactNumber: {
-      label: 'Contact number'
+      label: 'Telephone number'
     },
     contactEmail: {
-      label: 'Contact email address'
+      label: 'Email address'
     },
     contactAddress: {
       label: 'Billing address'
     },
+    hasPurchaseOrder: {
+      label: 'Do you have a purchase order number?',
+      options: {
+        yes: 'Yes',
+        no: 'No'
+      }
+    },
     purchaseOrder: {
       label: 'Purchase order number'
     },
+    alternativePaymentMethod: {
+      label: 'Provide details for your payment method'
+    },
     otherInformation: {
-      label: 'Any other billing information'
+      label: 'Other billing information (optional)'
+    },
+    declaredCurrent: {
+      label: 'These details are correct for the period {{ currentPeriod }}'
+    }
+  },
+  errors: {
+    contactName: {
+      required: 'Enter a contact name'
+    },
+    contactNumber: {
+      required: 'Enter a telephone number'
+    },
+    contactEmail: {
+      required: 'Enter an email address'
+    },
+    contactAddress: {
+      required: 'Enter an address'
+    },
+    purchaseOrder: {
+      required: 'Enter a purchase order number'
+    },
+    alternativePaymentMethod: {
+      required: 'Enter details for your payment method'
+    },
+    declaredCurrent: {
+      required: 'Select to confirm that all details are up to date'
     }
   },
   actions: {

--- a/pages/establishment/licence-fees/details/read/views/index.jsx
+++ b/pages/establishment/licence-fees/details/read/views/index.jsx
@@ -3,9 +3,32 @@ import Layout from '../../../views';
 import { ModelSummary, Link, Snippet } from '@ukhomeoffice/asl-components';
 
 export default function Details() {
+  const formatters = {
+    hasPurchaseOrder: {
+      format: (value, model) => {
+        switch (model.hasPurchaseOrder) {
+          case 'yes':
+            return 'Yes';
+          case 'no':
+            return 'No';
+          default:
+            return '-';
+        }
+      }
+    },
+    declaredCurrent: {
+      format: (value, model) => {
+        return model.declaredCurrent ? 'Yes' : 'No';
+      },
+      renderContext: {
+        currentPeriod: '6 April 2024 to 5 April 2025'
+      }
+    }
+  };
+
   return (
     <Layout tab={2}>
-      <ModelSummary />
+      <ModelSummary formatters={formatters} recurseOptionReveals />
       <Link page="establishment.fees.details.update" label={<Snippet>actions.editLink</Snippet>}/>
     </Layout>
   );

--- a/pages/establishment/licence-fees/details/schema/index.js
+++ b/pages/establishment/licence-fees/details/schema/index.js
@@ -1,20 +1,51 @@
 module.exports = {
   contactName: {
-    inputType: 'inputText'
+    inputType: 'inputText',
+    validate: ['required']
   },
   contactNumber: {
-    inputType: 'inputText'
+    inputType: 'inputText',
+    validate: ['required']
   },
   contactEmail: {
-    inputType: 'inputText'
+    inputType: 'inputText',
+    validate: ['required']
   },
   contactAddress: {
-    inputType: 'textarea'
+    inputType: 'textarea',
+    validate: ['required']
   },
-  purchaseOrder: {
-    inputType: 'inputText'
+  hasPurchaseOrder: {
+    inputType: 'radioGroup',
+    automapReveals: true,
+    validate: ['required'],
+    options: [
+      {
+        value: 'yes',
+        reveal: {
+          purchaseOrder: {
+            inputType: 'inputText',
+            validate: ['required']
+          }
+        }
+      },
+      {
+        value: 'no',
+        reveal: {
+          alternativePaymentMethod: {
+            inputType: 'textarea',
+            validate: ['required']
+          }
+        }
+      }
+    ]
   },
   otherInformation: {
     inputType: 'textarea'
+  },
+  declaredCurrent: {
+    inputType: 'declaration',
+    title: 'Confirm that all details are up to date',
+    validate: ['required']
   }
 };

--- a/pages/establishment/licence-fees/details/update/content/index.js
+++ b/pages/establishment/licence-fees/details/update/content/index.js
@@ -1,7 +1,4 @@
 const { merge } = require('lodash');
 const content = require('../../content');
 
-module.exports = merge({}, content, {
-  intro: 'These details can be used for any contact regarding billing or finances.',
-  inset: 'All fields are optional.'
-});
+module.exports = merge({}, content, {});

--- a/pages/establishment/licence-fees/details/update/views/index.jsx
+++ b/pages/establishment/licence-fees/details/update/views/index.jsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { FormLayout, Header, Snippet, Inset } from '@ukhomeoffice/asl-components';
+import { FormLayout, Header, Snippet } from '@ukhomeoffice/asl-components';
 import EstablishmentHeader from '../../../../../common/components/establishment-header';
 
 export default function Details() {
   const establishment = useSelector(state => state.static.establishment);
+  const formatters = {
+    declaredCurrent: {
+      renderContext: {
+        currentPeriod: '6 April 2024 to 5 April 2025'
+      }
+    }
+  };
+
   return (
-    <FormLayout openTasks={establishment.openTasks}>
+    <FormLayout openTasks={establishment.openTasks} formatters={formatters}>
       <Header
         title={<Snippet>title</Snippet>}
         subtitle={<EstablishmentHeader establishment={establishment}/>}
       />
-      <Snippet>intro</Snippet>
-      <Inset>
-        <Snippet>inset</Snippet>
-      </Inset>
     </FormLayout>
   );
 }

--- a/pages/establishment/licence-fees/views/index.jsx
+++ b/pages/establishment/licence-fees/views/index.jsx
@@ -94,7 +94,7 @@ export default function Fees({ tab, tabs, children, subtitle = '' }) {
             className="inline"
             onChange={onYearSelect}
             value={year}
-            nullOption={false}
+            nullOption={null}
           />
         </div>
         <Warning><Snippet>fees.disclaimer</Snippet></Warning>


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4474

- Add declaration that details are upto date
- Remove redundant intro text
- Fix reveal error messages not showing in the same order as they appear
- Fix dates showing with leading 0
- Include unvalidated fields in the model data passed to other validators

Draft: Still to do
- [ ] Update asl-constants version when https://github.com/UKHomeOffice/asl-components/pull/325 is merged