### PR TITLE
Fix flaky tab navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/pages",
-  "version": "31.4.3",
+  "version": "31.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/pages",
-      "version": "31.4.3",
+      "version": "31.4.4",
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "^15.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/pages",
-  "version": "31.4.3",
+  "version": "31.4.4",
   "description": "",
   "main": "index.js",
   "style": "pages/common/assets/sass/style.scss",

--- a/pages/project/read/views/index.jsx
+++ b/pages/project/read/views/index.jsx
@@ -92,12 +92,14 @@ export default function ProjectLandingPage() {
   const firstSectionName = sectionNames[0];
   const [activeSection, setActiveSection] = useState(firstSectionName);
 
+  const location = typeof window !== 'undefined' ? window.location : null;
+
   useEffect(() => {
-    const hash = (window.location.hash || '').substring(1);
-    if (hash && sectionNames.includes(hash)) {
-      setActiveSection(hash);
+    const sectionFromHash = (window?.location.hash || '').substring(1);
+    if (sectionFromHash && activeSection !== sectionFromHash && sectionNames.includes(sectionFromHash)) {
+      setActiveSection(sectionFromHash);
     }
-  });
+  }, [location?.hash, activeSection]);
 
   return (
     <div className="project-landing-page">


### PR DESCRIPTION
There looks to be a race condition where:

```mermaid
flowchart LR
    A[User clicks on tab] --> B[onClick updates active tab] 
    B --> C[Rerender triggers onEffect setting active tab to current hash]
    A --> D[Default link behaviour updates URL hash]
```

If the URL hash update happens after the onEffect then the active tab ends up being the old one.

This change addes the location to the dep array so when the hash is updated the onEffect is run again. It can cause a slight flicker where the browser renders new tab -> old tab -> new tab in quick succession, but that only happens when the race condition actually occurs and is better than the tab not changing.