### PR TITLE
[ASSB-1385] Use date-fns when formatting dates using constant formats

### DIFF
--- a/pages/pil/unscoped/list/schema/index.js
+++ b/pages/pil/unscoped/list/schema/index.js
@@ -1,13 +1,12 @@
-const moment = require('moment');
 const { dateFormat } = require('../../../../../constants');
-
-function formatDate(date) {
-  return date ? moment(date).format(dateFormat.long) : '-';
-}
+const { isValid: isValidDate, toDate, format: dateFormatter } = require('date-fns');
 
 function concatArray(arr) {
   return (arr || []).join(', ');
 }
+
+const formatDate = (date) =>
+  isValidDate(toDate(date)) ? dateFormatter(date, dateFormat.long) : '-';
 
 module.exports = {
   id: {

--- a/pages/project/schema/index.js
+++ b/pages/project/schema/index.js
@@ -1,9 +1,9 @@
 const { pick, merge } = require('lodash');
-const moment = require('moment');
 const { dateFormat } = require('../../../constants');
+const { isValid: isValidDate, toDate, format: dateFormatter } = require('date-fns');
 
 function formatCSVDate(date) {
-  return date ? moment(date).format(dateFormat.long) : '-';
+  return isValidDate(toDate(date)) ? dateFormatter(date, dateFormat.long) : '-';
 }
 
 const schema = {


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ASSB-1385
https://collaboration.homeoffice.gov.uk/jira/browse/ASSB-1386

There were two CSV schemas using moment to format dates using date-fns format strings. `d` is day of month in date-fns and numerical day of week in moment.js, so this was showing 0-6.

Switched to using date-fns.