### PR TITLE
Keycloak V22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/pages",
-  "version": "31.9.0",
+  "version": "31.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/pages",
-      "version": "31.9.0",
+      "version": "31.10.0",
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/pages",
-  "version": "31.9.0",
+  "version": "31.10.0",
   "description": "",
   "main": "index.js",
   "style": "pages/common/assets/sass/style.scss",


### PR DESCRIPTION
Keycloak Realm now using lower case, Keycloak URL now using V22 instance URI, mocha also updated.